### PR TITLE
修复首 Token 未纳入计算的 Bug，并完善 graph_infer_stream 的回退情况

### DIFF
--- a/infer/inference.py
+++ b/infer/inference.py
@@ -56,6 +56,63 @@ class InferenceEngine:
             float(alpha_decay),
         )
 
+    def _init_cuda_graph_state(self, token, state, out):
+        x_emb = self.model.z["emb.weight"][token]
+
+        static_input = torch.empty_like(x_emb, device="cuda")
+        static_state = [None, None, None]
+        static_state[0] = torch.empty_like(state[0], device="cuda")
+        static_state[1] = torch.empty_like(state[1], device="cuda")
+        static_state[2] = torch.empty_like(state[2], device="cuda")
+        static_output = torch.empty_like(out, device="cuda")
+
+        static_output = self.model.forward(static_input, static_state)
+
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            static_output = self.model.forward(static_input, static_state)
+
+        static_input.copy_(x_emb)
+        static_state[0].copy_(state[0])
+        static_state[1].copy_(state[1])
+        static_state[2].copy_(state[2])
+        static_output.copy_(out)
+
+        return static_input, static_state, static_output, g
+
+    def _sample_next_token(
+        self,
+        static_output,
+        alpha_presence,
+        alpha_frequency,
+        alpha_decay,
+        temperature,
+        top_k,
+        top_p,
+    ):
+        logits_reshaped = static_output.unsqueeze(0).float()
+
+        sample_rand_states = sample.setup_rand(random.randint(0, 2**63 - 1), 1)
+        penalties = torch.zeros(1, 65536).to(0)
+        new_tokens = sample.batch_sampling_repetition_temperature_topk_topp(
+            logits_reshaped,
+            penalties,
+            sample_rand_states,
+            alpha_presence,
+            alpha_frequency,
+            alpha_decay,
+            temperature,
+            top_k,
+            top_p,
+        ).tolist()
+        return new_tokens[0]
+
+    @staticmethod
+    def _cleanup_cuda_state(state):
+        del state
+        gc.collect()
+        torch.cuda.empty_cache()
+
     def _get_dynamic_scheduler(self, key):
         with self.dynamic_batch_lock:
             scheduler = self.dynamic_batch_schedulers.get(key)
@@ -929,26 +986,9 @@ class InferenceEngine:
             if token in stop_tokens:
                 return [""]
 
-            x_emb = self.model.z["emb.weight"][token]
-
-            static_input = torch.empty_like(x_emb, device="cuda")
-            static_state = [None, None, None]
-            static_state[0] = torch.empty_like(state[0], device="cuda")
-            static_state[1] = torch.empty_like(state[1], device="cuda")
-            static_state[2] = torch.empty_like(state[2], device="cuda")
-            static_output = torch.empty_like(out, device="cuda")
-
-            static_output = self.model.forward(static_input, static_state)
-
-            g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(g):
-                static_output = self.model.forward(static_input, static_state)
-
-            static_input.copy_(x_emb)
-            static_state[0].copy_(state[0])
-            static_state[1].copy_(state[1])
-            static_state[2].copy_(state[2])
-            static_output.copy_(out)
+            static_input, _static_state, static_output, g = self._init_cuda_graph_state(
+                token, state, out
+            )
 
             generated_tokens = [token]
 
@@ -957,23 +997,15 @@ class InferenceEngine:
                 static_input.copy_(x_emb)
 
                 g.replay()
-
-                logits_reshaped = static_output.unsqueeze(0).float()
-
-                sample_rand_states = sample.setup_rand(random.randint(0, 2**63 - 1), 1)
-                penalties = torch.zeros(1, 65536).to(0)
-                new_tokens = sample.batch_sampling_repetition_temperature_topk_topp(
-                    logits_reshaped,
-                    penalties,
-                    sample_rand_states,
+                token = self._sample_next_token(
+                    static_output,
                     alpha_presence,
                     alpha_frequency,
                     alpha_decay,
                     temperature,
                     top_k,
                     top_p,
-                ).tolist()
-                token = new_tokens[0]
+                )
                 if token in stop_tokens:
                     break
                 generated_tokens.append(token)
@@ -981,9 +1013,7 @@ class InferenceEngine:
             decoded = self.tokenizer.decode(generated_tokens, utf8_errors="ignore")
             return [decoded]
         finally:
-            del state
-            gc.collect()
-            torch.cuda.empty_cache()
+            self._cleanup_cuda_state(state)
 
     async def graph_infer_stream(
         self,
@@ -1068,49 +1098,24 @@ class InferenceEngine:
                 else:
                     token_buffer.append(token)
 
-                x_emb = self.model.z["emb.weight"][token]
-
-                static_input = torch.empty_like(x_emb, device="cuda")
-                static_state = [None, None, None]
-                static_state[0] = torch.empty_like(state[0], device="cuda")
-                static_state[1] = torch.empty_like(state[1], device="cuda")
-                static_state[2] = torch.empty_like(state[2], device="cuda")
-                static_output = torch.empty_like(out, device="cuda")
-
-                static_output = self.model.forward(static_input, static_state)
-
-                g = torch.cuda.CUDAGraph()
-                with torch.cuda.graph(g):
-                    static_output = self.model.forward(static_input, static_state)
-
-                static_input.copy_(x_emb)
-                static_state[0].copy_(state[0])
-                static_state[1].copy_(state[1])
-                static_state[2].copy_(state[2])
-                static_output.copy_(out)
+                static_input, _static_state, static_output, g = (
+                    self._init_cuda_graph_state(token, state, out)
+                )
 
                 for _ in range(max_generate_tokens - 1):
                     x_emb = self.model.z["emb.weight"][token]
                     static_input.copy_(x_emb)
 
                     g.replay()
-
-                    logits_reshaped = static_output.unsqueeze(0).float()
-
-                    sample_rand_states = sample.setup_rand(random.randint(0, 2**63 - 1), 1)
-                    penalties = torch.zeros(1, 65536).to(0)
-                    new_tokens = sample.batch_sampling_repetition_temperature_topk_topp(
-                        logits_reshaped,
-                        penalties,
-                        sample_rand_states,
+                    token = self._sample_next_token(
+                        static_output,
                         alpha_presence,
                         alpha_frequency,
                         alpha_decay,
                         temperature,
                         top_k,
                         top_p,
-                    ).tolist()
-                    token = new_tokens[0]
+                    )
                     if token in stop_tokens:
                         finish_reason = "stop"
                         break
@@ -1147,9 +1152,7 @@ class InferenceEngine:
             yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
 
         finally:
-            del state
-            gc.collect()
-            torch.cuda.empty_cache()
+            self._cleanup_cuda_state(state)
 
         yield "data: [DONE]\n\n"
 

--- a/test/test_inference_graph.py
+++ b/test/test_inference_graph.py
@@ -135,28 +135,30 @@ async def _collect_stream(iterator) -> list[str]:
     return chunks
 
 
-async def test_graph_generate_respects_max_generate_tokens() -> None:
-    engine = _make_engine()
-    batch_tokens = iter([12, 13])
-
+@contextmanager
+def _patch_sampler(
+    *,
+    gumbel_fn=None,
+    setup_rand_fn=None,
+    batch_sampling_fn=None,
+):
     original_sampler = inference_module.sampler_gumbel_batch
     original_setup_rand = getattr(inference_module.sample, "setup_rand")
     original_batch_sampling = getattr(
         inference_module.sample, "batch_sampling_repetition_temperature_topk_topp"
     )
     try:
-        inference_module.sampler_gumbel_batch = lambda logits, temp: FakeScalar(11)
-        setattr(inference_module.sample, "setup_rand", lambda seed, batch_size: None)
-        setattr(
-            inference_module.sample,
-            "batch_sampling_repetition_temperature_topk_topp",
-            lambda *args, **kwargs: FakeBatchTokens(next(batch_tokens)),
-        )
-        result = await engine.graph_generate(
-            inputs=["hello"],
-            stop_tokens=[0],
-            max_generate_tokens=2,
-        )
+        if gumbel_fn is not None:
+            inference_module.sampler_gumbel_batch = gumbel_fn
+        if setup_rand_fn is not None:
+            setattr(inference_module.sample, "setup_rand", setup_rand_fn)
+        if batch_sampling_fn is not None:
+            setattr(
+                inference_module.sample,
+                "batch_sampling_repetition_temperature_topk_topp",
+                batch_sampling_fn,
+            )
+        yield
     finally:
         inference_module.sampler_gumbel_batch = original_sampler
         setattr(inference_module.sample, "setup_rand", original_setup_rand)
@@ -166,6 +168,32 @@ async def test_graph_generate_respects_max_generate_tokens() -> None:
             original_batch_sampling,
         )
 
+
+@contextmanager
+def _patch_cuda_available(available: bool):
+    original_is_available = inference_module.torch.cuda.is_available
+    try:
+        inference_module.torch.cuda.is_available = lambda: available
+        yield
+    finally:
+        inference_module.torch.cuda.is_available = original_is_available
+
+
+async def test_graph_generate_respects_max_generate_tokens() -> None:
+    engine = _make_engine()
+    batch_tokens = iter([12, 13])
+
+    with _patch_sampler(
+        gumbel_fn=lambda logits, temp: FakeScalar(11),
+        setup_rand_fn=lambda seed, batch_size: None,
+        batch_sampling_fn=lambda *args, **kwargs: FakeBatchTokens(next(batch_tokens)),
+    ):
+        result = await engine.graph_generate(
+            inputs=["hello"],
+            stop_tokens=[0],
+            max_generate_tokens=2,
+        )
+
     _assert_equal(result, ["AB"], "graph_generate should cap output to max_generate_tokens")
     print("[PASS] test_graph_generate_respects_max_generate_tokens")
 
@@ -173,21 +201,13 @@ async def test_graph_generate_respects_max_generate_tokens() -> None:
 async def test_graph_infer_stream_stops_on_initial_stop_token() -> None:
     engine = _make_engine()
 
-    original_sampler = inference_module.sampler_gumbel_batch
-    original_batch_sampling = getattr(
-        inference_module.sample, "batch_sampling_repetition_temperature_topk_topp"
-    )
-    try:
-        inference_module.sampler_gumbel_batch = lambda logits, temp: FakeScalar(0)
+    def _unexpected_batch_sampling(*args, **kwargs):
+        raise AssertionError("graph_infer_stream should not sample again after initial stop token")
 
-        def _unexpected_batch_sampling(*args, **kwargs):
-            raise AssertionError("graph_infer_stream should not sample again after initial stop token")
-
-        setattr(
-            inference_module.sample,
-            "batch_sampling_repetition_temperature_topk_topp",
-            _unexpected_batch_sampling,
-        )
+    with _patch_sampler(
+        gumbel_fn=lambda logits, temp: FakeScalar(0),
+        batch_sampling_fn=_unexpected_batch_sampling,
+    ):
         chunks = await _collect_stream(
             engine.graph_infer_stream(
                 inputs=["hello"],
@@ -195,13 +215,6 @@ async def test_graph_infer_stream_stops_on_initial_stop_token() -> None:
                 max_generate_tokens=3,
                 chunk_size=2,
             )
-        )
-    finally:
-        inference_module.sampler_gumbel_batch = original_sampler
-        setattr(
-            inference_module.sample,
-            "batch_sampling_repetition_temperature_topk_topp",
-            original_batch_sampling,
         )
 
     combined = "".join(chunks)
@@ -242,9 +255,8 @@ async def test_graph_infer_stream_falls_back_without_cuda() -> None:
         args=SimpleNamespace(),
         rocm_flag=False,
     )
-    original_is_available = inference_module.torch.cuda.is_available
-    try:
-        inference_module.torch.cuda.is_available = lambda: False
+
+    with _patch_cuda_available(False):
         chunks = await _collect_stream(
             engine.graph_infer_stream(
                 inputs=["hello"],
@@ -253,8 +265,6 @@ async def test_graph_infer_stream_falls_back_without_cuda() -> None:
                 chunk_size=1,
             )
         )
-    finally:
-        inference_module.torch.cuda.is_available = original_is_available
 
     combined = "".join(chunks)
     if "fallback-stream" not in combined:


### PR DESCRIPTION
改动：
- graph_generate 和 graph_infer_stream 现在把首 token 计入预算，不再出现 1 + max_generate_tokens 的超限
- 首 token 命中 stop 会立即结束，不再继续采样
- 在 rocm_flag 或 torch.cuda.is_available() 为假时，graph_infer_stream 会直接回退到 dynamic_batch_infer_stream

新增：
- 新增了 test/test_inference_graph.py，覆盖了情况：预算上限、首 token stop、CUDA 不可用回退