### PR TITLE
Fix stale prefix-cache test and intermittent openai completions hang

### DIFF
--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 from contextlib import asynccontextmanager
 from contextlib import suppress
 
@@ -94,7 +95,25 @@ async def watch_disconnect(request: Request, cancel_token: CancellationToken):
         raise
 
 
-async def cleanup_disconnect_watcher(task, timeout: float = 1.0, poll_interval: float = 0.05):
+# Defaults for how long cleanup_disconnect_watcher retries cancel() before
+# giving up on a stuck disconnect-watcher (see that function's comment below
+# for why this retry loop exists at all). Override via env vars if a
+# deployment needs different behavior under heavier event-loop load; an
+# abandoned watcher is harmless either way, it exits on its own once the
+# client actually disconnects.
+DISCONNECT_WATCHER_CLEANUP_TIMEOUT_S = float(
+    os.environ.get("RWKV_DISCONNECT_WATCHER_CLEANUP_TIMEOUT_S", "1.0")
+)
+DISCONNECT_WATCHER_CLEANUP_POLL_INTERVAL_S = float(
+    os.environ.get("RWKV_DISCONNECT_WATCHER_CLEANUP_POLL_INTERVAL_S", "0.05")
+)
+
+
+async def cleanup_disconnect_watcher(
+    task,
+    timeout: float = DISCONNECT_WATCHER_CLEANUP_TIMEOUT_S,
+    poll_interval: float = DISCONNECT_WATCHER_CLEANUP_POLL_INTERVAL_S,
+):
     # watch_disconnect polls request.is_disconnected(), which wraps its receive() call in an
     # already-cancelled anyio.CancelScope (see Starlette's Request.is_disconnected). If task.cancel()
     # lands while the watcher is inside that scope, anyio can treat the injected CancelledError as

--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -94,10 +94,24 @@ async def watch_disconnect(request: Request, cancel_token: CancellationToken):
         raise
 
 
-async def cleanup_disconnect_watcher(task):
-    task.cancel()
-    with suppress(asyncio.CancelledError):
-        await task
+async def cleanup_disconnect_watcher(task, timeout: float = 1.0, poll_interval: float = 0.05):
+    # watch_disconnect polls request.is_disconnected(), which wraps its receive() call in an
+    # already-cancelled anyio.CancelScope (see Starlette's Request.is_disconnected). If task.cancel()
+    # lands while the watcher is inside that scope, anyio can treat the injected CancelledError as
+    # satisfying its own (already-resolved) cancellation and swallow it, so the task keeps looping
+    # instead of stopping -- an unbounded `await task` after cancel() then hangs forever (confirmed
+    # live via asyncio task-stack introspection: the watcher was still asleep in its polling loop
+    # after cancel() had already been called). Poll with repeated cancel() attempts instead of
+    # awaiting the task directly, and give up after `timeout` rather than block the response --
+    # an abandoned watcher is harmless, it will exit on its own once the client actually disconnects.
+    deadline = asyncio.get_event_loop().time() + timeout
+    while not task.done():
+        task.cancel()
+        if asyncio.get_event_loop().time() >= deadline:
+            return
+        await asyncio.sleep(poll_interval)
+    with suppress(asyncio.CancelledError, Exception):
+        task.result()
 
 
 @asynccontextmanager
@@ -127,16 +141,26 @@ async def reserve_prefill_capacity(
             )
 
 
-async def run_sync_with_disconnect_watch(request: Request, func, **kwargs):
-    cancel_token = CancellationToken()
-    watcher = asyncio.create_task(watch_disconnect(request, cancel_token))
+async def run_sync_with_disconnect_watch(
+    request: Request, func, cancel_token: CancellationToken | None = None, **kwargs
+):
+    # If the caller already has a watcher running against this request (e.g. via
+    # reserve_prefill_capacity(..., cancel_token=cancel_token)), reuse its token instead of
+    # starting a second concurrent watcher: two tasks polling request.is_disconnected() at once
+    # can race inside Starlette's self-cancelling CancelScope and leave one watcher task stuck
+    # forever, which then hangs whoever awaits it in cleanup_disconnect_watcher.
+    owns_watcher = cancel_token is None
+    if cancel_token is None:
+        cancel_token = CancellationToken()
+    watcher = asyncio.create_task(watch_disconnect(request, cancel_token)) if owns_watcher else None
     try:
         result = await run_in_threadpool(func, cancel_token=cancel_token, **kwargs)
         if cancel_token.is_cancelled():
             raise InferenceCancelled("request disconnected")
         return result
     finally:
-        await cleanup_disconnect_watcher(watcher)
+        if watcher is not None:
+            await cleanup_disconnect_watcher(watcher)
 
 
 async def _cleanup_prefill_stream_response(

--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -104,10 +104,11 @@ async def cleanup_disconnect_watcher(task, timeout: float = 1.0, poll_interval: 
     # after cancel() had already been called). Poll with repeated cancel() attempts instead of
     # awaiting the task directly, and give up after `timeout` rather than block the response --
     # an abandoned watcher is harmless, it will exit on its own once the client actually disconnects.
-    deadline = asyncio.get_event_loop().time() + timeout
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
     while not task.done():
         task.cancel()
-        if asyncio.get_event_loop().time() >= deadline:
+        if loop.time() >= deadline:
             return
         await asyncio.sleep(poll_interval)
     with suppress(asyncio.CancelledError, Exception):

--- a/API_servers/router/openai_routes.py
+++ b/API_servers/router/openai_routes.py
@@ -2,7 +2,6 @@ import json
 import os
 import time
 from typing import Any
-import asyncio
 
 from fastapi import APIRouter, Request
 
@@ -10,7 +9,6 @@ from infer.cancellation import CancellationToken, InferenceCancelled, PrefillBsz
 from state_manager.state_pool import get_state_manager
 
 from API_servers.router.common import (
-    cleanup_disconnect_watcher,
     client_closed_response,
     emit_finish_reason_chunk,
     extract_sse_payload,
@@ -18,7 +16,6 @@ from API_servers.router.common import (
     prefill_bsz_limit_response,
     prefill_sse_response,
     reserve_prefill_capacity,
-    watch_disconnect,
 )
 from API_servers.router.schemas import ChatRequest
 
@@ -320,27 +317,23 @@ async def openai_chat_completions(request: Request):
             )
             return prefill_sse_response(request, stream, cancel_token, 1)
 
-        async with reserve_prefill_capacity(request, 1):
-            cancel_token = CancellationToken()
-            watcher = asyncio.create_task(watch_disconnect(request, cancel_token))
-            try:
-                result_text, finish_reason = await engine.singe_infer(
-                    prompt=prompt_formatted,
-                    max_length=req.max_tokens,
-                    temperature=req.temperature,
-                    top_k=req.top_k,
-                    top_p=req.top_p,
-                    alpha_presence=req.alpha_presence,
-                    alpha_frequency=req.alpha_frequency,
-                    alpha_decay=req.alpha_decay,
-                    stop_tokens=req.stop_tokens,
-                    prefix_cache_manager=prefix_cache_manager,
-                    cancel_token=cancel_token,
-                )
-                if cancel_token.is_cancelled():
-                    raise InferenceCancelled("request disconnected")
-            finally:
-                await cleanup_disconnect_watcher(watcher)
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, 1, cancel_token=cancel_token):
+            result_text, finish_reason = await engine.singe_infer(
+                prompt=prompt_formatted,
+                max_length=req.max_tokens,
+                temperature=req.temperature,
+                top_k=req.top_k,
+                top_p=req.top_p,
+                alpha_presence=req.alpha_presence,
+                alpha_frequency=req.alpha_frequency,
+                alpha_decay=req.alpha_decay,
+                stop_tokens=req.stop_tokens,
+                prefix_cache_manager=prefix_cache_manager,
+                cancel_token=cancel_token,
+            )
+            if cancel_token.is_cancelled():
+                raise InferenceCancelled("request disconnected")
 
         message, response_finish_reason = build_openai_message_response(
             result_text, finish_reason, body

--- a/API_servers/router/state_routes.py
+++ b/API_servers/router/state_routes.py
@@ -73,10 +73,12 @@ async def state_chat_completions(request: Request):
         return prefill_sse_response(request, stream, cancel_token, 1)
 
     try:
-        async with reserve_prefill_capacity(request, 1):
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, 1, cancel_token=cancel_token):
             results = await run_sync_with_disconnect_watch(
                 request,
                 engine.batch_generate_state,
+                cancel_token=cancel_token,
                 prompts=prompts,
                 state=state,
                 max_length=req.max_tokens,
@@ -210,10 +212,12 @@ async def multi_state_chat_completions(request: Request):
         return prefill_sse_response(request, stream_with_dialogue_idx(), cancel_token, 1)
 
     try:
-        async with reserve_prefill_capacity(request, 1):
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, 1, cancel_token=cancel_token):
             results = await run_sync_with_disconnect_watch(
                 request,
                 engine.batch_generate_state,
+                cancel_token=cancel_token,
                 prompts=prompts,
                 state=state,
                 max_length=req.max_tokens,

--- a/API_servers/router/v1_routes.py
+++ b/API_servers/router/v1_routes.py
@@ -73,10 +73,12 @@ async def chat_completions(request: Request):
         return prefill_sse_response(request, stream, cancel_token, len(req.contents))
 
     try:
-        async with reserve_prefill_capacity(request, len(req.contents)):
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, len(req.contents), cancel_token=cancel_token):
             results = await run_sync_with_disconnect_watch(
                 request,
                 engine.batch_generate,
+                cancel_token=cancel_token,
                 prompts=req.contents,
                 max_length=req.max_tokens,
                 temperature=req.temperature,
@@ -122,10 +124,12 @@ async def batch_translate(request: Request):
     ]
 
     try:
-        async with reserve_prefill_capacity(request, len(prompts)):
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, len(prompts), cancel_token=cancel_token):
             translated_texts = await run_sync_with_disconnect_watch(
                 request,
                 engine.batch_generate,
+                cancel_token=cancel_token,
                 prompts=prompts,
                 max_length=2048,
                 temperature=1.0,
@@ -191,10 +195,12 @@ async def fim_completions(request: Request):
         return prefill_sse_response(request, stream, cancel_token, len(prompts))
 
     try:
-        async with reserve_prefill_capacity(request, len(prompts)):
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, len(prompts), cancel_token=cancel_token):
             results = await run_sync_with_disconnect_watch(
                 request,
                 engine.batch_generate,
+                cancel_token=cancel_token,
                 prompts=prompts,
                 max_length=req.max_tokens,
                 temperature=req.temperature,

--- a/API_servers/router/v2_routers.py
+++ b/API_servers/router/v2_routers.py
@@ -53,10 +53,12 @@ async def chat_completions_v2(request: Request):
         return prefill_sse_response(request, stream, cancel_token, len(req.contents))
 
     try:
-        async with reserve_prefill_capacity(request, len(req.contents)):
+        cancel_token = CancellationToken()
+        async with reserve_prefill_capacity(request, len(req.contents), cancel_token=cancel_token):
             results = await run_sync_with_disconnect_watch(
                 request,
                 engine.batch_generate_v2,
+                cancel_token=cancel_token,
                 prompts=req.contents,
                 max_length=req.max_tokens,
                 temperature=req.temperature,

--- a/test/test_prefix_state_cache.py
+++ b/test/test_prefix_state_cache.py
@@ -31,33 +31,35 @@ def test_prefix_cache_longest_match_and_disk_reload():
         _reset_manager(db_path)
         manager = state_pool.StateCacheManager()
 
-        state_64 = [
+        bucket_small, bucket_large = state_pool.PREFIX_CACHE_BUCKETS[:2]
+
+        state_small = [
             torch.tensor([1.0]),
             torch.tensor([2.0]),
-            torch.tensor(64, dtype=torch.int32),
+            torch.tensor(bucket_small, dtype=torch.int32),
         ]
-        logits_64 = torch.tensor([0.1, 0.2, 0.3])
-        tokens_64 = list(range(64))
+        logits_small = torch.tensor([0.1, 0.2, 0.3])
+        tokens_small = list(range(bucket_small))
 
-        state_128 = [
+        state_large = [
             torch.tensor([10.0]),
             torch.tensor([20.0]),
-            torch.tensor(128, dtype=torch.int32),
+            torch.tensor(bucket_large, dtype=torch.int32),
         ]
-        logits_128 = torch.tensor([0.5, 0.6, 0.7])
-        tokens_128 = list(range(128))
+        logits_large = torch.tensor([0.5, 0.6, 0.7])
+        tokens_large = list(range(bucket_large))
 
-        assert manager.put_prefix_state(tokens_64, state_64, logits_64) is True
-        assert manager.put_prefix_state(tokens_128, state_128, logits_128) is True
+        assert manager.put_prefix_state(tokens_small, state_small, logits_small) is True
+        assert manager.put_prefix_state(tokens_large, state_large, logits_large) is True
 
-        prompt_tokens = list(range(160))
+        prompt_tokens = list(range(bucket_large + 32))
         match = manager.match_prefix_state(prompt_tokens, device="cpu")
         assert match is not None
-        assert match["matched_tokens"] == 128
+        assert match["matched_tokens"] == bucket_large
         assert match["cache_source"] == "l2_ram"
-        assert torch.equal(match["state"][2], torch.tensor(128, dtype=torch.int32))
+        assert torch.equal(match["state"][2], torch.tensor(bucket_large, dtype=torch.int32))
 
-        entry = manager.prefix_entry_index[state_pool._serialize_token_ids(tokens_128)]
+        entry = manager.prefix_entry_index[state_pool._serialize_token_ids(tokens_large)]
         manager._persist_prefix_task(entry)
 
         with manager.cache_lock:
@@ -70,9 +72,9 @@ def test_prefix_cache_longest_match_and_disk_reload():
 
         disk_match = manager.match_prefix_state(prompt_tokens, device="cpu")
         assert disk_match is not None
-        assert disk_match["matched_tokens"] == 128
+        assert disk_match["matched_tokens"] == bucket_large
         assert disk_match["cache_source"] == "disk"
-        assert torch.equal(disk_match["logits"], logits_128)
+        assert torch.equal(disk_match["logits"], logits_large)
 
         manager.db_conn.close()
         state_pool.StateCacheManager._instance = None


### PR DESCRIPTION
## Summary
- `test/test_prefix_state_cache.py` called `put_prefix_state()` with 64/128-token prefixes, but `put_prefix_state` only accepts lengths exactly matching `PREFIX_CACHE_BUCKETS` (1024..8192). Rewrote the test to use real bucket sizes instead of loosening the production check.
- `POST /openai/v1/chat/completions` (non-streaming) intermittently hung forever when `use_prefix_cache` was true. Root-caused via live `asyncio` task-stack introspection during a reproduced hang: `cleanup_disconnect_watcher` did `task.cancel()` followed by an unbounded `await task` on a `watch_disconnect` task polling `request.is_disconnected()`. Starlette's `is_disconnected()` wraps its `receive()` call in an already-cancelled `anyio.CancelScope`, so an externally injected `cancel()` landing inside that window can be swallowed by anyio as satisfying its own scope, leaving the watcher looping forever and the awaiting request stuck until the client actually disconnects.
- Fixed `cleanup_disconnect_watcher` to poll with bounded, repeated `cancel()` attempts instead of blocking indefinitely on the task's completion, and stopped every `reserve_prefill_capacity` call site from spinning up a second, redundant `watch_disconnect` task on the same request (they now reuse the `cancel_token` param `reserve_prefill_capacity` already accepted for this).
- The retry timeout/poll interval for `cleanup_disconnect_watcher` (default 1.0s / 0.05s) are now **configurable via `RWKV_DISCONNECT_WATCHER_CLEANUP_TIMEOUT_S` / `RWKV_DISCONNECT_WATCHER_CLEANUP_POLL_INTERVAL_S`** rather than fixed constants.

## Test plan
- [x] `uv run pytest test/test_prefix_state_cache.py` passes
- [x] Verified against a live 2.9b instance: 20/20 concurrent and 20/20 sequential `use_prefix_cache:true` non-stream requests succeed (previously ~50% hung under the same repro)
- [x] Full `test/test_curl.sh` smoke suite passes, including the previously-flaky non-stream `use_prefix_cache:true` call