### PR TITLE
Add templated `chats` field to /big_batch/completions

### DIFF
--- a/API_servers/router/schemas.py
+++ b/API_servers/router/schemas.py
@@ -6,6 +6,11 @@ from pydantic import BaseModel
 class ChatRequest(BaseModel):
     model: str = "rwkv7"
     contents: list[str] = []
+    # Batched alternative to `contents` for /big_batch/completions: each item
+    # is an OpenAI-style {"messages": [...], "system": ...} dict, chat-templated
+    # server-side the same way as /openai/v1/chat/completions (single source of
+    # truth for the prompt format, so it stays correct across model finetunes).
+    chats: list[dict] = []
     messages: list[dict] = []
     system: Optional[str] = None
     prefix: list[str] = []

--- a/API_servers/router/v1_routes.py
+++ b/API_servers/router/v1_routes.py
@@ -11,6 +11,7 @@ from API_servers.router.common import (
     reserve_prefill_capacity,
     run_sync_with_disconnect_watch,
 )
+from API_servers.router.openai_routes import format_openai_prompt
 from API_servers.router.schemas import ChatRequest, TranslateRequest, TranslateResponse
 
 
@@ -239,13 +240,18 @@ async def big_batch_completions(request: Request):
     if auth_error is not None:
         return auth_error
 
+    if req.chats:
+        prompts = [format_openai_prompt(chat, req.enable_think) for chat in req.chats]
+    else:
+        prompts = req.contents
+
     cancel_token = CancellationToken()
     stream = engine.big_batch_stream(
-        prompts=req.contents,
+        prompts=prompts,
         max_length=req.max_tokens,
         temperature=req.temperature,
         stop_tokens=req.stop_tokens,
         chunk_size=req.chunk_size,
         cancel_token=cancel_token,
     )
-    return prefill_sse_response(request, stream, cancel_token, len(req.contents))
+    return prefill_sse_response(request, stream, cancel_token, len(prompts))


### PR DESCRIPTION
## Summary
- `/big_batch/completions` previously only accepted `contents: list[str]` — raw, untemplated prompt strings with no chat formatting applied.
- A caller sending bare user-message text through this path (with any system message silently dropped) gets no chat template applied, which can produce hallucinated/off-topic output from instruction-tuned models — confirmed via raw-vs-templated A/B testing to be a prompt-formatting issue, not a concurrency bug.
- Adds `ChatRequest.chats: list[dict]` (schemas.py) — each item is an OpenAI-style `{"messages": [...], "system": ...}` dict. `big_batch_completions` now builds each prompt via `format_openai_prompt()` — the same function `/openai/v1/chat/completions` already uses — when `req.chats` is set, falling back to the legacy raw `req.contents` path otherwise.
- **Fully backward compatible**: existing callers using `contents` see no behavior change.
- Makes this repo the single source of truth for the chat-template string; a future finetune that changes the expected prompt format only requires touching `format_openai_prompt()` here, not any client repo.

## Test plan
- [x] Verified `format_openai_prompt()` produces identical templated output to the existing `/openai/v1/chat/completions` path for the same messages.
- [x] Confirmed the legacy `contents`-only path is unaffected (fallback branch untouched).