### PR TITLE
Fix auth security gaps found by swarm review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@ rwkv_sessions.db
 ShareGPT_V3_unfiltered_cleaned_split.json
 .codex
 infer/rwkv_batch/cuda/third_party/cutlass/*
+
+# secrets / local env
+env.sh
+service_run.sh
+
+# model weights (downloaded separately, not for git)
+models/
+
+# logs and local test artifacts
+*.log

--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -1,4 +1,5 @@
 import asyncio
+import hmac
 import json
 from contextlib import asynccontextmanager
 from contextlib import suppress
@@ -39,7 +40,7 @@ def prefill_bsz_limit_response(exc: PrefillBszLimitExceeded):
 
 
 def check_password(body_password, password):
-    if password and body_password != password:
+    if password and not hmac.compare_digest(str(body_password or ""), password):
         return json_response(401, {"error": "Unauthorized: invalid or missing password"})
     return None
 

--- a/API_servers/router/openai_routes.py
+++ b/API_servers/router/openai_routes.py
@@ -1,3 +1,4 @@
+import hmac
 import json
 import os
 import time
@@ -176,9 +177,9 @@ def extract_bearer_token(request: Request):
 def check_openai_auth(request: Request, body: dict, password):
     if not password:
         return None
-    bearer_token = extract_bearer_token(request)
-    body_password = body.get("password")
-    if bearer_token == password or body_password == password:
+    bearer_token = extract_bearer_token(request) or ""
+    body_password = str(body.get("password") or "")
+    if hmac.compare_digest(bearer_token, password) or hmac.compare_digest(body_password, password):
         return None
     return json_response(401, {"error": "Unauthorized: invalid or missing password"})
 

--- a/API_servers/router/schemas.py
+++ b/API_servers/router/schemas.py
@@ -34,6 +34,7 @@ class TranslateRequest(BaseModel):
     target_lang: str
     text_list: list[str]
     placeholders: Optional[list[str]] = None
+    password: Optional[str] = None
 
 
 class TranslateResponse(BaseModel):

--- a/API_servers/router/v1_routes.py
+++ b/API_servers/router/v1_routes.py
@@ -113,8 +113,13 @@ async def chat_completions(request: Request):
 @router.post("/translate/v1/batch-translate")
 async def batch_translate(request: Request):
     engine = request.app.state.engine
+    password = request.app.state.password
     body = await request.json()
     req = TranslateRequest(**body)
+
+    auth_error = check_password(req.password, password)
+    if auth_error:
+        return auth_error
 
     prompts = [
         create_translation_prompt(req.source_lang, req.target_lang, text)

--- a/app_big_batch.py
+++ b/app_big_batch.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import atexit
 import gc
+import hmac
 import json
 import os
 import queue
@@ -365,7 +366,7 @@ def create_app(
         except Exception as exc:
             return json_response(400, {"error": f"invalid request: {exc}"})
 
-        if password and req.password != password:
+        if password and not hmac.compare_digest(str(req.password or ""), password):
             return json_response(401, {"error": "Unauthorized: invalid or missing password"})
 
         if not req.contents:


### PR DESCRIPTION
## Summary
Found during an automated code review of this server:

- **`/translate/v1/batch-translate` was completely unauthenticated** even when the server was started with `--password` — any client could hit this endpoint with zero credentials, unlike every other route.
- Password comparisons in `common.py`, `openai_routes.py`, and `app_big_batch.py` used plain `!=` string comparison instead of a constant-time comparison, which is a timing side-channel that could in principle let an attacker recover the password byte-by-byte via response-time measurement. Switched to `hmac.compare_digest`.
- `.gitignore`: added `env.sh`, `service_run.sh` (these commonly contain a live deployment password in local setups), `models/` (large binary weights not meant for version control), and `*.log`.

## Test plan
- [x] Confirmed `/translate/v1/batch-translate` now returns 401 without a valid password when the server has one configured, matching every other authenticated route.
- [x] Confirmed `hmac.compare_digest` swap is a drop-in behavioral replacement (still rejects wrong/missing passwords, still accepts the correct one) — verified against a running instance.