### PR TITLE
Throttle refresh_max_prefill_bsz() to stop event-loop stalls

### DIFF
--- a/infer/rwkv_batch/rwkv7.py
+++ b/infer/rwkv_batch/rwkv7.py
@@ -6,6 +6,7 @@
 
 from typing import List
 import os
+import time
 current_path = os.path.dirname(os.path.abspath(__file__))
 
 import torch
@@ -198,6 +199,8 @@ class RWKV_x070(MyModule):
         z['blocks.0.att.v2'] = z['blocks.0.att.a2'] # actually ignored
         self.refresh_max_prefill_bsz()
         self.max_prefill_bsz_limit = int(self.max_prefill_bsz)
+        self._prefill_bsz_refresh_interval_s = 2.0
+        self._prefill_bsz_last_refresh = time.monotonic()
         print(
             f"max_prefill_bsz={self.max_prefill_bsz} "
             f"max_prefill_bsz_limit={self.max_prefill_bsz_limit} "
@@ -205,7 +208,18 @@ class RWKV_x070(MyModule):
         )
 
     # Estimate the largest batch size that fits current free VRAM for one chunked prefill.
+    # Throttled: torch.cuda.empty_cache()/mem_get_info() are blocking CUDA syncs, and this
+    # is called on every prefill-queue admit/release from the asyncio event loop, so an
+    # unthrottled refresh stalls all concurrent requests. Reuse the last estimate within
+    # _prefill_bsz_refresh_interval_s instead of resyncing every call.
     def refresh_max_prefill_bsz(self):
+        now = time.monotonic()
+        last = getattr(self, "_prefill_bsz_last_refresh", 0.0)
+        interval = getattr(self, "_prefill_bsz_refresh_interval_s", 2.0)
+        if hasattr(self, "max_prefill_bsz") and (now - last) < interval:
+            return self.max_prefill_bsz
+        self._prefill_bsz_last_refresh = now
+
         torch.cuda.empty_cache()
         free_bytes, total_bytes = torch.cuda.mem_get_info()
         dtype_bytes = torch.empty((), dtype=DTYPE).element_size()

--- a/infer/rwkv_batch/rwkv7.py
+++ b/infer/rwkv_batch/rwkv7.py
@@ -199,7 +199,14 @@ class RWKV_x070(MyModule):
         z['blocks.0.att.v2'] = z['blocks.0.att.a2'] # actually ignored
         self.refresh_max_prefill_bsz()
         self.max_prefill_bsz_limit = int(self.max_prefill_bsz)
-        self._prefill_bsz_refresh_interval_s = 2.0
+        # Default is 2.0s; override with RWKV_PREFILL_BSZ_REFRESH_INTERVAL_S
+        # if your deployment needs a different tradeoff (shorter = notices
+        # VRAM freed by other processes on a shared GPU sooner, at the cost
+        # of more frequent blocking CUDA syncs; longer = fewer syncs, slower
+        # to react to freed VRAM).
+        self._prefill_bsz_refresh_interval_s = float(
+            os.environ.get("RWKV_PREFILL_BSZ_REFRESH_INTERVAL_S", "2.0")
+        )
         self._prefill_bsz_last_refresh = time.monotonic()
         print(
             f"max_prefill_bsz={self.max_prefill_bsz} "


### PR DESCRIPTION
## Summary
`refresh_max_prefill_bsz()` calls `torch.cuda.empty_cache()` + `mem_get_info()`, both blocking CUDA syncs. `inference.py`'s prefill-queue admission logic calls this on **every single** prefill admit/release from the asyncio event loop — so an unthrottled refresh stalls all concurrent requests on the same event loop each time, not just the one triggering the refresh.

Cache the last estimate and only actually resync every 2s by default, falling back to the cached value for calls within that window. **Configurable via the `RWKV_PREFILL_BSZ_REFRESH_INTERVAL_S` env var** — the interval trades off reaction time to freed VRAM against sync frequency, which is a tradeoff a deployment should be able to tune (especially relevant if the GPU is shared with other processes). Minimal, backward-compatible change — same return type/semantics, just throttled.

## Test plan
- [x] Verified against a live instance under concurrent load: prefill admission latency no longer includes a blocking CUDA sync on every single admit/release.
- [x] Confirmed the VRAM-budget estimate still tracks real usage within the 2s window (doesn't go stale enough to matter in practice — CUDA memory pressure doesn't change that fast under normal request patterns).
- [x] Confirmed `RWKV_PREFILL_BSZ_REFRESH_INTERVAL_S` is correctly plumbed through with a real model construction on GPU (env var value shows up as the actual instance attribute used by the throttle check).