### PR TITLE
Eliminate redundant GPU->CPU->GPU token round-trip in decode loops

### DIFF
--- a/infer/batch_inference.py
+++ b/infer/batch_inference.py
@@ -118,14 +118,15 @@ class BatchInferenceMixin:
                     alpha_decay,
                     active_mask=active_mask,
                 )
-                new_tokens = [[token] for token in new_tokens_tensor.tolist()]
-                for i in range(batch_size):
-                    if finished[i]:
-                        new_tokens[i][0] = 0
-                out = self.model.forward_batch(new_tokens, state).float()
+                # Single host sync for stop-string detection (needs Python ints). The
+                # sampled tensor is fed straight back into the model as-is, avoiding the
+                # extra host->device torch.tensor(idxs) rebuild the old List[List[int]]
+                # path incurred inside forward_batch.
+                new_tokens = new_tokens_tensor.tolist()
+                out = self.model.forward_batch(new_tokens_tensor, state).float()
 
                 for i in range(batch_size):
-                    tok = new_tokens[i][0]
+                    tok = new_tokens[i]
                     if finished[i]:
                         continue
 
@@ -203,11 +204,12 @@ class BatchInferenceMixin:
                     alpha_decay,
                     active_mask=active_mask,
                 )
-                new_tokens = [[token] for token in new_tokens_tensor.tolist()]
-                for i in range(batch_size):
-                    if finished[i]:
-                        new_tokens[i][0] = 0
-                out = self.model.forward_batch(new_tokens, state).float()
+                # Single host sync for stop-string detection (needs Python ints). The
+                # sampled tensor is fed straight back into the model as-is, avoiding the
+                # extra host->device torch.tensor(idxs) rebuild the old List[List[int]]
+                # path incurred inside forward_batch.
+                new_tokens = new_tokens_tensor.tolist()
+                out = self.model.forward_batch(new_tokens_tensor, state).float()
                 max_length -= 1
 
                 contents_to_send = [""] * batch_size
@@ -216,7 +218,7 @@ class BatchInferenceMixin:
                     if finished[i]:
                         continue
 
-                    tok = new_tokens[i][0]
+                    tok = new_tokens[i]
                     content, should_stop = self._ingest_token_with_stop(stop_states[i], tok)
                     if content:
                         text_buffers[i] += content
@@ -311,7 +313,7 @@ class BatchInferenceMixin:
 
             for _ in range(max_length):
                 self._raise_if_cancelled(cancel_token)
-                new_tokens = inference_deps.get_sample().batch_sampling_repetition_temperature_topk_topp(
+                new_tokens_tensor = inference_deps.get_sample().batch_sampling_repetition_temperature_topk_topp(
                     out,
                     penalties,
                     sample_rand_states,
@@ -321,16 +323,15 @@ class BatchInferenceMixin:
                     temperature,
                     top_k,
                     top_p,
-                ).tolist()
-                new_tokens = [[token] for token in new_tokens]
-                out = self.model.forward_batch(new_tokens, state).float()
+                )
+                # Feed the sampled tokens straight back into the model as a GPU tensor (no
+                # host round-trip); the single .tolist() sync below is only for stop-string
+                # detection, which needs plain Python ints.
+                out = self.model.forward_batch(new_tokens_tensor, state).float()
+                new_tokens = new_tokens_tensor.tolist()
 
                 for i in range(batch_size):
-                    tok = (
-                        new_tokens[i][0]
-                        if isinstance(new_tokens[i], list)
-                        else new_tokens[i]
-                    )
+                    tok = new_tokens[i]
                     if finished[i]:
                         continue
 
@@ -393,7 +394,7 @@ class BatchInferenceMixin:
 
             while not all(finished) and max_length > 0:
                 self._raise_if_cancelled(cancel_token)
-                new_tokens = inference_deps.get_sample().batch_sampling_repetition_temperature_topk_topp(
+                new_tokens_tensor = inference_deps.get_sample().batch_sampling_repetition_temperature_topk_topp(
                     out,
                     penalties,
                     sample_rand_states,
@@ -403,9 +404,12 @@ class BatchInferenceMixin:
                     temperature,
                     top_k,
                     top_p,
-                ).tolist()
-                new_tokens = [[token] for token in new_tokens]
-                out = self.model.forward_batch(new_tokens, state).float()
+                )
+                # Feed the sampled tokens straight back into the model as a GPU tensor (no
+                # host round-trip); the single .tolist() sync below is only for stop-string
+                # detection, which needs plain Python ints.
+                out = self.model.forward_batch(new_tokens_tensor, state).float()
+                new_tokens = new_tokens_tensor.tolist()
                 max_length -= 1
 
                 contents_to_send = [""] * batch_size
@@ -414,11 +418,7 @@ class BatchInferenceMixin:
                     if finished[i]:
                         continue
 
-                    tok = (
-                        new_tokens[i][0]
-                        if isinstance(new_tokens[i], list)
-                        else new_tokens[i]
-                    )
+                    tok = new_tokens[i]
 
                     content, should_stop = self._ingest_token_with_stop(stop_states[i], tok)
                     if content:

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -45,13 +45,17 @@ class BigBatchMixin:
                     new_tokens_tensor = inference_deps.get_sampler_gumbel_batch()(
                         logits=out, temp=temperature
                     )
+
+                    # Feed the sampled tokens straight back into the model as a GPU tensor
+                    # (no host round-trip); the single .tolist() sync below is only for
+                    # stop-string detection, which needs plain Python ints.
+                    prev_out = out
+                    out = self.model.forward_batch(new_tokens_tensor, state)
+                    del prev_out
+
                     new_tokens = new_tokens_tensor.tolist()
                     del new_tokens_tensor
                     new_tokens_tensor = None
-
-                    prev_out = out
-                    out = self.model.forward_batch(new_tokens, state)
-                    del prev_out
 
                     max_length -= 1
                     step_count += 1
@@ -62,11 +66,7 @@ class BigBatchMixin:
                         if finished[i]:
                             continue
 
-                        tok = (
-                            new_tokens[i][0]
-                            if isinstance(new_tokens[i], list)
-                            else new_tokens[i]
-                        )
+                        tok = new_tokens[i][0]
 
                         content, should_stop = self._ingest_token_with_stop(
                             stop_states[i], tok

--- a/infer/rwkv_batch/rwkv7.py
+++ b/infer/rwkv_batch/rwkv7.py
@@ -266,6 +266,11 @@ class RWKV_x070(MyModule):
         
     # Run batched prompts as equal-length prefill chunks of at most 256 tokens.
     def forward_batch(self, tokens, state, full_output=False): # will modify state in-place
+        # Decode-step fast path: a [B] or [B,1] GPU LongTensor of sampled token ids is fed
+        # straight into the batched sequence path, avoiding the GPU->CPU .tolist() sync plus
+        # the CPU->GPU torch.tensor(idxs) rebuild that the List[List[int]] path incurs.
+        if isinstance(tokens, torch.Tensor):
+            return self.forward_batch_same_length(tokens, state, full_output)
         assert type(tokens) is list
         lengths = [len(x) for x in tokens]
         bsz = len(tokens)
@@ -300,6 +305,8 @@ class RWKV_x070(MyModule):
 
     # Run one equal-length batch chunk through the batched sequence path.
     def forward_batch_same_length(self, tokens, state, full_output=False):
+        if isinstance(tokens, torch.Tensor):
+            return self.forward_seq_batch_tensor(tokens, state, full_output)
         assert type(tokens) is list
         assert len(set([len(x) for x in tokens])) == 1, 'here all sequences must have the same length'
         return self.forward_seq_batch(tokens, state, full_output)
@@ -402,6 +409,45 @@ class RWKV_x070(MyModule):
             x = F.layer_norm(x, (self.n_embd,), weight=z['ln_out.weight'], bias=z['ln_out.bias'])
             x = F.linear(x, z['head.weight'])
             state[2] += len(idxs[0])
+            return x
+
+    @MyFunction
+    # Decode-step fast path equivalent to forward_seq_batch: accepts a [B] or [B,1] GPU tensor
+    # of token ids directly and embeds it, skipping the host->device torch.tensor(idxs) rebuild
+    # the List[List[int]] path needs. Numerically identical to forward_seq_batch for the same ids.
+    def forward_seq_batch_tensor(self, idxs:torch.Tensor, state:List[torch.Tensor], full_output:bool=False):
+        with torch.no_grad(): 
+            z = self.z
+            if idxs.dim() == 1:
+                idxs = idxs.unsqueeze(1)
+            idxs = idxs.long()
+            x = z['emb.weight'][idxs]
+
+            v_first = torch.empty_like(x)
+            for i in range(self.n_layer):
+                bbb = f'blocks.{i}.'
+                att = f'blocks.{i}.att.'
+                ffn = f'blocks.{i}.ffn.'
+
+                xx = F.layer_norm(x, (self.n_embd,), weight=z[bbb+'ln1.weight'], bias=z[bbb+'ln1.bias'])
+
+                xx, v_first = RWKV_x070_TMix_seq_batch(i, self.n_head, self.head_size, xx, state[0][i], v_first, state[1][i],
+                    z[att+'x_r'], z[att+'x_w'], z[att+'x_k'], z[att+'x_v'], z[att+'x_a'], z[att+'x_g'],
+                    z[att+'w0'], z[att+'w1'], z[att+'w2'], z[att+'a0'], z[att+'a1'], z[att+'a2'], z[att+'v0'], z[att+'v1'], z[att+'v2'],
+                    z[att+'g1'], z[att+'g2'], z[att+'k_k'], z[att+'k_a'], z[att+'r_k'],
+                    z[att+'receptance.weight'], z[att+'key.weight'], z[att+'value.weight'], z[att+'output.weight'],
+                    z[att+'ln_x.weight'], z[att+'ln_x.bias'], state[2])
+                x = x + xx
+
+                xx = F.layer_norm(x, (self.n_embd,), weight=z[bbb+'ln2.weight'], bias=z[bbb+'ln2.bias'])
+
+                xx = RWKV_x070_CMix_seq_batch(xx, state[0][i], z[ffn+'x_k'], z[ffn+'key.weight'], z[ffn+'value.weight'])
+                x = x + xx
+            
+            if not full_output: x = x[:,-1,:]
+            x = F.layer_norm(x, (self.n_embd,), weight=z['ln_out.weight'], bias=z['ln_out.bias'])
+            x = F.linear(x, z['head.weight'])
+            state[2] += idxs.size(1)
             return x
 
 ########################################################################################################


### PR DESCRIPTION
## Summary
Every decode step previously did `new_tokens_tensor.tolist()` then rewrapped the ints as `[[t], ...]` and passed that Python list into `forward_batch()`, which internally rebuilt a GPU tensor via `torch.tensor(idxs, device=...)` — reconstructing on-device data that started on-device. Feeds the sampled tensor straight back into the model instead, doing a single `.tolist()` only where CPU ints are actually needed (stop-string detection).

**Changes:**
- `infer/rwkv_batch/rwkv7.py`: new `forward_seq_batch_tensor` TorchScript method, a faithful copy of `forward_seq_batch` that embeds a GPU `LongTensor` directly instead of reconstructing one from a Python list. `forward_batch`/`forward_batch_same_length` dispatch to it when given a `torch.Tensor`; the list-based prefill path is untouched.
- `infer/batch_inference.py`, `infer/big_batch.py`: decode loops feed the sampler's tensor output directly to `forward_batch` and `.tolist()` it only once, for stop-detection.

## Test plan
- [x] TorchScript compiles; model loads; both list-path and tensor-path run without error.
- [x] After warm-up (there's a pre-existing, unrelated first-call non-determinism after model load, reproducible even on unmodified code — not introduced by this change), list-path vs tensor-path are bit-identical across 10+ trials on both outputs and state tensors.
- [x] End-to-end `batch_generate()` with fixed seed/temperature produces byte-identical text on baseline vs modified code, including a 2-prompt case where one prompt stops early and the other continues 30+ steps.

**Honest note on performance**: no measurable speedup observed at bsz=32 (~0.3%, within noise) — the eliminated op is a small CPU-side list reconstruction dwarfed by GPU forward time at that batch size. The value here is removing a genuinely pointless round-trip for code cleanliness; may matter more at smaller batch sizes or slower host↔device interconnects. Not claiming a measured latency win at typical batch sizes.

Not touched: `app_big_batch.py` has the same `tolist`→list→`forward_batch` pattern but is a separate entry point outside this change's scope.