### PR TITLE
Fix 3 issues found in deep swarm review: crash bug, DB race, silent SSE truncation

### DIFF
--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import traceback
 from contextlib import asynccontextmanager
 from contextlib import suppress
 
@@ -239,6 +240,21 @@ def prefill_sse_response(
         except asyncio.CancelledError:
             cancel_token.cancel()
             raise
+        except Exception:
+            # Any other failure (e.g. a bug in the decode loop) would
+            # otherwise propagate past this generator uncaught, which
+            # Starlette/uvicorn logs loudly but delivers to the client as
+            # an abruptly-closed connection: no "data: [DONE]" marker and
+            # no error payload, so a naive SSE consumer that just appends
+            # `delta.content` until EOF can't distinguish a truncated
+            # response from a complete one. Log with the full traceback
+            # (matching how this was previously surfaced, so nothing about
+            # visibility in the server log regresses) and send an explicit
+            # error chunk before terminating, so the stream always ends
+            # with a client-visible signal one way or another.
+            cancel_token.cancel()
+            print(f"[SSE] unhandled exception in stream body:\n{traceback.format_exc()}")
+            yield f"data: {json.dumps({'error': {'message': 'internal error during generation', 'type': 'stream_error'}}, ensure_ascii=False)}\n\n"
         finally:
             _schedule_prefill_stream_cleanup(
                 request,

--- a/API_servers/router/state_routes.py
+++ b/API_servers/router/state_routes.py
@@ -292,11 +292,18 @@ async def state_status(request: Request):
             )
 
         for session_id in all_states["database"]:
-            manager.db_cursor.execute(
-                "SELECT last_updated FROM sessions WHERE session_id = ?",
-                (session_id,),
-            )
-            row = manager.db_cursor.fetchone()
+            # Must hold db_lock: manager.db_cursor is a single shared SQLite
+            # cursor (opened with check_same_thread=False for cross-coroutine
+            # use), and every other call site that touches it in
+            # state_manager/state_pool.py wraps the access in this same lock.
+            # Without it, a concurrent write (e.g. /state/save) executing on
+            # the same cursor object can interleave with this read.
+            with manager.db_lock:
+                manager.db_cursor.execute(
+                    "SELECT last_updated FROM sessions WHERE session_id = ?",
+                    (session_id,),
+                )
+                row = manager.db_cursor.fetchone()
             if row:
                 timestamp = row[0]
                 readable_time = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")

--- a/app_big_batch.py
+++ b/app_big_batch.py
@@ -68,7 +68,13 @@ class BigBatchEngine:
         new_tokens = None
 
         try:
-            with torch.inference_mode():
+            # NOTE: no_grad(), not inference_mode() -- see infer/big_batch.py's
+            # identical fix and its inline comment for why inference_mode()'s
+            # thread-local guard is unsafe here under concurrent asyncio
+            # requests. This file (app_big_batch.py) is not currently used
+            # by the live service (which launches via app.py), but fixed
+            # here too so a future revival doesn't reintroduce the bug.
+            with torch.no_grad():
                 state = self.model.generate_zero_state(batch_size)
                 encoded_prompts = [self.tokenizer.encode(prompt) for prompt in prompts]
                 out = self.model.forward_batch(encoded_prompts, state)
@@ -202,7 +208,13 @@ class BigBatchEngine:
         new_tokens = None
 
         try:
-            with torch.inference_mode():
+            # NOTE: no_grad(), not inference_mode() -- see infer/big_batch.py's
+            # identical fix and its inline comment for why inference_mode()'s
+            # thread-local guard is unsafe here under concurrent asyncio
+            # requests. This file (app_big_batch.py) is not currently used
+            # by the live service (which launches via app.py), but fixed
+            # here too so a future revival doesn't reintroduce the bug.
+            with torch.no_grad():
                 state = self.model.generate_zero_state(batch_size)
                 encoded_prompts = [self.tokenizer.encode(prompt) for prompt in prompts]
                 out = self.model.forward_batch(encoded_prompts, state)

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -25,7 +25,27 @@ class BigBatchMixin:
         new_tokens = None
 
         try:
-            with inference_deps.get_torch().inference_mode():
+            # NOTE: must be no_grad(), not inference_mode(). inference_mode()'s
+            # guard is thread-local (not coroutine-local), so under concurrent
+            # asyncio requests sharing this event-loop thread, one request's
+            # `with` block can exit while another is still inside its own,
+            # desyncing the ambient mode mid-flight for the still-running one.
+            # Tensors created while the guard *was* active stay permanently
+            # tagged as inference tensors even after the desync, so a later
+            # in-place op on them (e.g. sampler_gumbel_batch's logits.mul_())
+            # raises "Inplace update to inference tensor outside InferenceMode"
+            # -- this fired repeatedly in production before this fix (see
+            # git log for the commit introducing this comment for the full
+            # repro/root-cause writeup). no_grad() only affects autograd-graph
+            # construction, checked live at op-dispatch time, so it has no
+            # such hazard -- the tradeoff is that no_grad() (unlike
+            # inference_mode()) won't loudly reject an in-place mutation of a
+            # decode-loop tensor that somehow got captured by reference and
+            # outlived this scope; not a concern today since every tensor
+            # here is discarded at the end of each streamed response, but
+            # worth knowing if this loop is ever refactored to persist state
+            # across requests.
+            with inference_deps.get_torch().no_grad():
                 state = self.model.generate_zero_state(batch_size)
                 encoded_prompts = [self.tokenizer.encode(p) for p in prompts]
                 out = self._forward_batch_prompts_chunked(

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -34,9 +34,8 @@ class BigBatchMixin:
             # tagged as inference tensors even after the desync, so a later
             # in-place op on them (e.g. sampler_gumbel_batch's logits.mul_())
             # raises "Inplace update to inference tensor outside InferenceMode"
-            # -- this fired repeatedly in production before this fix (see
-            # git log for the commit introducing this comment for the full
-            # repro/root-cause writeup). no_grad() only affects autograd-graph
+            # -- this fired repeatedly in production before this fix.
+            # no_grad() only affects autograd-graph
             # construction, checked live at op-dispatch time, so it has no
             # such hazard -- the tradeoff is that no_grad() (unlike
             # inference_mode()) won't loudly reject an in-place mutation of a


### PR DESCRIPTION
## Summary

Three separate bugs found by an automated code review and independently re-verified with reproductions and negative controls before/after each fix.

### 1. Recurring production crash in `/big_batch/completions` (`infer/big_batch.py` + defensive fix in `app_big_batch.py`)

`torch.inference_mode()` wraps the whole decode loop, but its guard is **thread-local, not coroutine-local**. Under concurrent asyncio requests sharing the event-loop thread, one request's `with` block can exit while another is still inside its own, desyncing the ambient mode mid-flight for the still-running one. Tensors created while the guard *was* active stay permanently tagged as inference tensors even after the desync, so a later in-place op (`sampler_gumbel_batch`'s `logits.mul_()`) raises `RuntimeError: Inplace update to inference tensor outside InferenceMode`.

Fix: swap `inference_mode()` for `no_grad()`. No downside for this use case — every tensor here is discarded per-request, never mixed with a live autograd graph, and this server does no training.

- [x] Reproduced the exact crash with a standalone repro script (deterministic, not a timing-dependent flake) and with a full `big_batch_stream()`-driving test (20 concurrent staggered-completion streams — fails on trial 0 without the fix, passes 20/20 with it).
- [x] Confirmed output is byte-identical before/after (the swap has zero numerical impact, purely a concurrency-safety fix).

### 2. Unlocked DB race in `/state/status` (`API_servers/router/state_routes.py`)

`state_status`'s per-session DB read called `manager.db_cursor.execute()`/`.fetchone()` directly, with no `db_lock` — the only such call site in the codebase, vs. 11 other correctly-locked sites in `state_manager/state_pool.py`. The DB connection is opened with `check_same_thread=False` specifically for cross-coroutine use, making the missing lock a real, reachable race, not theoretical.

- [x] A targeted concurrency test (200 concurrent locked reads + a continuous concurrent writer thread) passes with zero errors after the fix.
- [x] The same test reimplementing the original unlocked code path reliably reproduces `sqlite3.ProgrammingError: Recursive use of cursors not allowed` on 3/3 runs.
- [x] Traced the call chain to confirm no deadlock risk from the added lock.

### 3. Silently-truncated SSE stream on any unhandled exception (`API_servers/router/common.py`)

`prefill_sse_response`'s `body()` generator — the single choke point for all SSE/streaming routes — only caught 3 specific exception types. Any other exception (like bug #1 above) propagated uncaught, and the client got an abruptly-closed connection: no `data: [DONE]` marker, no error payload. A naive consumer appending `delta.content` until EOF can't distinguish a truncated response from a complete one.

Fix: added `except Exception:` that logs the full traceback (preserving today's log-based visibility) and yields a client-visible `data: {"error": ...}` chunk before terminating.

- [x] Verified via a mocked crashing-stream test: catches the exception, yields a proper error+termination signal; confirmed the unfixed code lets the exception propagate fully uncaught.

## Notes

Grepped the whole tree for each of these three bug patterns and confirmed no other unfixed instance exists anywhere in the codebase — these are complete fixes for each pattern, not partial.