### PR TITLE
Cap max_tokens to prevent prefill-slot starvation DoS; clean 400s for invalid requests

### DIFF
--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import ValidationError
 from starlette.background import BackgroundTask
 from starlette.concurrency import run_in_threadpool
 
@@ -42,6 +43,22 @@ def check_password(body_password, password):
     if password and body_password != password:
         return json_response(401, {"error": "Unauthorized: invalid or missing password"})
     return None
+
+
+def parse_request_model(model_cls, body: dict):
+    """Build a pydantic request model from a parsed JSON body, converting
+    ValidationError (e.g. our max_tokens ceiling, or any other field
+    constraint) into a clean 400 response instead of letting it propagate
+    as an uncaught exception (which FastAPI turns into an opaque 500 with no
+    indication of what was wrong with the request).
+
+    Returns (model_instance, None) on success, or (None, error_response) on
+    failure -- callers should check the second element and return it as-is.
+    """
+    try:
+        return model_cls(**body), None
+    except ValidationError as exc:
+        return None, json_response(400, {"error": f"invalid request: {exc}"})
 
 
 def normalize_state_prompts(prompts: list[str], reuse_existing_state: bool) -> list[str]:

--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -55,6 +55,10 @@ def parse_request_model(model_cls, body: dict):
     Returns (model_instance, None) on success, or (None, error_response) on
     failure -- callers should check the second element and return it as-is.
     """
+    if not isinstance(body, dict):
+        return None, json_response(
+            400, {"error": "invalid request: expected a JSON object"}
+        )
     try:
         return model_cls(**body), None
     except ValidationError as exc:

--- a/API_servers/router/openai_routes.py
+++ b/API_servers/router/openai_routes.py
@@ -5,6 +5,7 @@ from typing import Any
 import asyncio
 
 from fastapi import APIRouter, Request
+from pydantic import ValidationError
 
 from infer.cancellation import CancellationToken, InferenceCancelled, PrefillBszLimitExceeded
 from state_manager.state_pool import get_state_manager
@@ -363,6 +364,8 @@ async def openai_chat_completions(request: Request):
         return client_closed_response()
     except PrefillBszLimitExceeded as exc:
         return prefill_bsz_limit_response(exc)
+    except ValidationError as exc:
+        return json_response(400, {"error": f"invalid request: {exc}"})
     except json.JSONDecodeError as exc:
         return json_response(400, {"error": f"Invalid JSON: {str(exc)}"})
     except Exception as exc:

--- a/API_servers/router/schemas.py
+++ b/API_servers/router/schemas.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 from pydantic import BaseModel, field_validator
@@ -10,8 +11,11 @@ from pydantic import BaseModel, field_validator
 # concurrent requests with max_tokens=999999999 (bsz=1 each, so individually
 # admitted instantly) can each occupy one budget slot indefinitely, starving
 # every other client even though the shared prefill-bsz admission control is
-# working exactly as designed. See auth-sweep.md for the full writeup.
-MAX_ALLOWED_TOKENS = 32768
+# working exactly as designed. 32768 is a default, not a hard requirement --
+# override with the RWKV_MAX_ALLOWED_TOKENS env var if your deployment needs
+# a different ceiling (e.g. a smaller trusted-only deployment that wants a
+# tighter cap, or a larger one that legitimately needs longer generations).
+MAX_ALLOWED_TOKENS = int(os.environ.get("RWKV_MAX_ALLOWED_TOKENS", "32768"))
 
 
 class ChatRequest(BaseModel):

--- a/API_servers/router/schemas.py
+++ b/API_servers/router/schemas.py
@@ -1,6 +1,17 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+# Hard ceiling on max_tokens (decode-step budget per request). This is not a
+# GPU-memory limit (RWKV's recurrent state is O(1) in sequence length, unlike
+# a transformer KV-cache), it's a DoS/fairness guard: reserve_prefill_capacity
+# holds a request's slot against the shared max_prefill_bsz admission budget
+# for the *entire* generation, not just prefill. Without a cap, a handful of
+# concurrent requests with max_tokens=999999999 (bsz=1 each, so individually
+# admitted instantly) can each occupy one budget slot indefinitely, starving
+# every other client even though the shared prefill-bsz admission control is
+# working exactly as designed. See auth-sweep.md for the full writeup.
+MAX_ALLOWED_TOKENS = 32768
 
 
 class ChatRequest(BaseModel):
@@ -27,6 +38,15 @@ class ChatRequest(BaseModel):
     session_id: Optional[str] = None
     dialogue_idx: Optional[int] = 0
     use_prefix_cache: bool = True
+
+    @field_validator("max_tokens")
+    @classmethod
+    def _clamp_max_tokens(cls, value: int) -> int:
+        if value > MAX_ALLOWED_TOKENS:
+            raise ValueError(
+                f"max_tokens={value} exceeds the server limit of {MAX_ALLOWED_TOKENS}"
+            )
+        return value
 
 
 class TranslateRequest(BaseModel):

--- a/API_servers/router/state_routes.py
+++ b/API_servers/router/state_routes.py
@@ -12,6 +12,7 @@ from API_servers.router.common import (
     client_closed_response,
     json_response,
     normalize_state_prompts,
+    parse_request_model,
     prefill_bsz_limit_response,
     prefill_sse_response,
     reserve_prefill_capacity,
@@ -28,7 +29,9 @@ async def state_chat_completions(request: Request):
     engine = request.app.state.engine
     password = request.app.state.password
     body = await request.json()
-    req = ChatRequest(**body)
+    req, parse_error = parse_request_model(ChatRequest, body)
+    if parse_error is not None:
+        return parse_error
     session_id = req.session_id
 
     if len(req.contents) > 1:
@@ -123,7 +126,9 @@ async def multi_state_chat_completions(request: Request):
     engine = app_state.engine
     password = app_state.password
     body = await request.json()
-    req = ChatRequest(**body)
+    req, parse_error = parse_request_model(ChatRequest, body)
+    if parse_error is not None:
+        return parse_error
 
     auth_error = check_password(req.password, password)
     if auth_error is not None:

--- a/API_servers/router/v1_routes.py
+++ b/API_servers/router/v1_routes.py
@@ -6,6 +6,7 @@ from infer.cancellation import CancellationToken, InferenceCancelled, PrefillBsz
 from API_servers.router.common import (
     check_password,
     client_closed_response,
+    parse_request_model,
     prefill_bsz_limit_response,
     prefill_sse_response,
     reserve_prefill_capacity,
@@ -49,7 +50,9 @@ async def chat_completions(request: Request):
     engine = request.app.state.engine
     password = request.app.state.password
     body = await request.json()
-    req = ChatRequest(**body)
+    req, parse_error = parse_request_model(ChatRequest, body)
+    if parse_error is not None:
+        return parse_error
 
     auth_error = check_password(req.password, password)
     if auth_error is not None:
@@ -114,7 +117,9 @@ async def chat_completions(request: Request):
 async def batch_translate(request: Request):
     engine = request.app.state.engine
     body = await request.json()
-    req = TranslateRequest(**body)
+    req, parse_error = parse_request_model(TranslateRequest, body)
+    if parse_error is not None:
+        return parse_error
 
     prompts = [
         create_translation_prompt(req.source_lang, req.target_lang, text)
@@ -163,7 +168,9 @@ async def fim_completions(request: Request):
     engine = request.app.state.engine
     password = request.app.state.password
     body = await request.json()
-    req = ChatRequest(**body)
+    req, parse_error = parse_request_model(ChatRequest, body)
+    if parse_error is not None:
+        return parse_error
 
     auth_error = check_password(req.password, password)
     if auth_error is not None:
@@ -233,7 +240,9 @@ async def big_batch_completions(request: Request):
     engine = request.app.state.engine
     password = request.app.state.password
     body = await request.json()
-    req = ChatRequest(**body)
+    req, parse_error = parse_request_model(ChatRequest, body)
+    if parse_error is not None:
+        return parse_error
 
     auth_error = check_password(req.password, password)
     if auth_error is not None:

--- a/API_servers/router/v2_routers.py
+++ b/API_servers/router/v2_routers.py
@@ -5,6 +5,7 @@ from infer.cancellation import CancellationToken, InferenceCancelled, PrefillBsz
 from API_servers.router.common import (
     check_password,
     client_closed_response,
+    parse_request_model,
     prefill_bsz_limit_response,
     prefill_sse_response,
     reserve_prefill_capacity,
@@ -29,7 +30,9 @@ async def chat_completions_v2(request: Request):
     engine = request.app.state.engine
     password = request.app.state.password
     body = await request.json()
-    req = V2ChatRequest(**body)
+    req, parse_error = parse_request_model(V2ChatRequest, body)
+    if parse_error is not None:
+        return parse_error
 
     auth_error = check_password(req.password, password)
     if auth_error is not None:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ python app.py --model-path /path/to/model-w8a16 \
 and CUTLASS checkpoints use different layouts and cannot be interchanged.
 - if no password, you can do not add ```--password``` flag
 
+`max_tokens` per request is capped at `32768` by default (a fairness/DoS
+guard, since a request holds its prefill-admission slot for its entire
+generation) — override with the `RWKV_MAX_ALLOWED_TOKENS` env var if your
+deployment needs a different ceiling.
+
 
 ## Test API quickly
 ```bash


### PR DESCRIPTION
## Summary
An exhaustive route-by-route auth audit found no missing/ignored auth checks (all 13 routes correctly authenticated or correctly public-by-design), but did surface a real DoS vector: `max_tokens` had no upper bound, so a handful of concurrent requests with a huge `max_tokens` could hold prefill-queue slots effectively indefinitely, starving other clients.

- Adds `MAX_ALLOWED_TOKENS` as a pydantic `field_validator` on `ChatRequest.max_tokens`, defaulting to `32768`. **Configurable via the `RWKV_MAX_ALLOWED_TOKENS` env var** — the underlying DoS mechanism this guards against is universal, but the right ceiling is deployment-specific, so it shouldn't be a hardcoded constant.
- Adds a `parse_request_model()` helper in `API_servers/router/common.py` that converts an uncaught `pydantic.ValidationError` into a clean 400 response instead of letting FastAPI turn it into an opaque 500. Applied across `v1_routes.py`, `v2_routers.py`, `state_routes.py`; `openai_routes.py` gets the equivalent behavior via its existing try/except structure (already had its own JSON-decode-error handling).
- `parse_request_model()` also guards against a non-dict top-level JSON body (e.g. a list or string), which previously slipped past the `ValidationError`-only catch and produced an uncaught `TypeError` → 500.

## Verification
Live-tested every auth-bearing route for: huge `max_tokens` → clean 400 (fires before the SSE stream opens on streaming routes, not mid-stream), missing/wrong password → 401, and normal small requests completing correctly, across all 9 auth-bearing routes. Confirmed validation happens before any GPU-adjacent admission-control step in every route. Checked the default 32768 ceiling against every documented and client-side `max_tokens` usage in the repo — no legitimate use case gets broken. Verified the `RWKV_MAX_ALLOWED_TOKENS` override actually changes live server behavior end-to-end (tested both a lowered and default limit against a running server).