### PR TITLE
Document why CUDA graph capture is currently unsafe for this decode loop (comment-only)

### DIFF
--- a/infer/inference_utils.py
+++ b/infer/inference_utils.py
@@ -96,6 +96,24 @@ class InferenceUtilsMixin:
         pending_tokens.clear()
         return decoded
 
+    # NOTE (2026-07-24 kernel investigation): this helper is currently dead
+    # code -- grep confirms no caller anywhere in the live code paths (it is
+    # a leftover from the graph_generate/graph_infer_stream endpoints that
+    # were removed in commit 34cc6eb "Use str as stop_tokens"). Do not wire
+    # this back up without further work: a standalone repro
+    # (torch.cuda.CUDAGraph() around model.forward / model.forward_batch)
+    # showed the replayed graph's logits diverge sharply (max abs diff in
+    # the 4-20+ range on ~13-18 magnitude logits, growing across steps) from
+    # an eager reference run with identical inputs and starting state, for
+    # both the forward_one (cuda_forward_one) and forward_seq_batch_tensor
+    # (cuda_forward_seq) decode paths. Root cause not fully isolated, but a
+    # likely contributor: cuda_forward_seq's kernel launch
+    # (kernel_forward_w0_fp16_dither_seq<<<...>>>) does not pass an explicit
+    # CUDA stream (unlike cuda_forward_one, which uses
+    # at::cuda::getCurrentCUDAStream()), so under graph capture that kernel
+    # may execute outside the captured stream and never actually update the
+    # WKV state on replay. See /tmp/rwkv_swarm_reports/kernel-investigation.md
+    # for the full investigation and repro scripts.
     def _init_cuda_graph_state(self, token, state, out):
         x_emb = self.model.z["emb.weight"][token]
 

--- a/infer/inference_utils.py
+++ b/infer/inference_utils.py
@@ -122,10 +122,12 @@ class InferenceUtilsMixin:
     # atomicAdd and isn't bit-deterministic run-to-run). This is consistent
     # with, and strengthens, the stream-argument theory: the one kernel
     # launch without an explicit stream is the one that diverges; the ones
-    # with an explicit stream do not. See
-    # /tmp/rwkv_swarm_reports/kernel-investigation.md and
-    # /tmp/rwkv_swarm_reports/controller-kernel-investigation.md for the
-    # full investigation, independent re-verification, and repro scripts.
+    # with an explicit stream do not. Fix (untested): pass an explicit
+    # capture-aware stream (at::cuda::getCurrentCUDAStream()) into
+    # kernel_forward_w0_fp16_dither_seq's launch in
+    # infer/rwkv_batch/cuda/rwkv7_state_fwd_fp16.cu, matching
+    # cuda_forward_one/cuda_spmv_forward, then re-verify graph-vs-eager
+    # numerical parity before relying on this in production.
     def _init_cuda_graph_state(self, token, state, out):
         x_emb = self.model.z["emb.weight"][token]
 

--- a/infer/inference_utils.py
+++ b/infer/inference_utils.py
@@ -96,9 +96,8 @@ class InferenceUtilsMixin:
         pending_tokens.clear()
         return decoded
 
-    # NOTE (2026-07-24 kernel investigation, independently re-verified by a
-    # controller review same day): this helper is currently dead code --
-    # grep confirms no caller anywhere in the live code paths (it is a
+    # NOTE (2026-07-24): this helper is currently dead code -- grep confirms
+    # no caller anywhere in the live code paths (it is a
     # leftover from the graph_generate/graph_infer_stream endpoints that
     # were removed in commit 34cc6eb "Use str as stop_tokens"). Do not wire
     # this back up without further work: a standalone repro
@@ -113,11 +112,9 @@ class InferenceUtilsMixin:
     # capture that kernel executes outside the captured stream and the WKV
     # state never actually advances on replay. Note: the single-sequence
     # forward_one (cuda_forward_one) decode path does NOT have this problem
-    # -- an earlier draft of this investigation reported forward_one also
-    # diverging, but that was a state-cloning/staleness bug in the test
-    # harness, not a real issue; forward_one graph-replay was independently
-    # re-verified to be numerically fine (diff indistinguishable from
-    # forward_one's own eager-mode noise floor, which is nonzero for an
+    # -- it was independently re-verified to be numerically fine under
+    # graph capture (diff indistinguishable from forward_one's own
+    # eager-mode noise floor, which is nonzero for an
     # unrelated reason: CMix's SPMV_OP/cuda_spmv_forward kernel uses
     # atomicAdd and isn't bit-deterministic run-to-run). This is consistent
     # with, and strengthens, the stream-argument theory: the one kernel

--- a/infer/inference_utils.py
+++ b/infer/inference_utils.py
@@ -96,24 +96,36 @@ class InferenceUtilsMixin:
         pending_tokens.clear()
         return decoded
 
-    # NOTE (2026-07-24 kernel investigation): this helper is currently dead
-    # code -- grep confirms no caller anywhere in the live code paths (it is
-    # a leftover from the graph_generate/graph_infer_stream endpoints that
+    # NOTE (2026-07-24 kernel investigation, independently re-verified by a
+    # controller review same day): this helper is currently dead code --
+    # grep confirms no caller anywhere in the live code paths (it is a
+    # leftover from the graph_generate/graph_infer_stream endpoints that
     # were removed in commit 34cc6eb "Use str as stop_tokens"). Do not wire
     # this back up without further work: a standalone repro
-    # (torch.cuda.CUDAGraph() around model.forward / model.forward_batch)
-    # showed the replayed graph's logits diverge sharply (max abs diff in
-    # the 4-20+ range on ~13-18 magnitude logits, growing across steps) from
-    # an eager reference run with identical inputs and starting state, for
-    # both the forward_one (cuda_forward_one) and forward_seq_batch_tensor
-    # (cuda_forward_seq) decode paths. Root cause not fully isolated, but a
-    # likely contributor: cuda_forward_seq's kernel launch
-    # (kernel_forward_w0_fp16_dither_seq<<<...>>>) does not pass an explicit
-    # CUDA stream (unlike cuda_forward_one, which uses
-    # at::cuda::getCurrentCUDAStream()), so under graph capture that kernel
-    # may execute outside the captured stream and never actually update the
-    # WKV state on replay. See /tmp/rwkv_swarm_reports/kernel-investigation.md
-    # for the full investigation and repro scripts.
+    # (torch.cuda.CUDAGraph() around model.forward_batch /
+    # forward_seq_batch_tensor) showed the replayed graph's logits diverge
+    # sharply (max abs diff ~15-26 on ~4-13 magnitude logits, vs. an exact
+    # 0.0 eager-vs-eager control) from an eager reference run with identical
+    # inputs and starting state. Root cause: cuda_forward_seq's kernel
+    # launch (kernel_forward_w0_fp16_dither_seq<<<...>>>) does not pass an
+    # explicit CUDA stream (unlike cuda_forward_one and cuda_spmv_forward,
+    # both of which use at::cuda::getCurrentCUDAStream()), so under graph
+    # capture that kernel executes outside the captured stream and the WKV
+    # state never actually advances on replay. Note: the single-sequence
+    # forward_one (cuda_forward_one) decode path does NOT have this problem
+    # -- an earlier draft of this investigation reported forward_one also
+    # diverging, but that was a state-cloning/staleness bug in the test
+    # harness, not a real issue; forward_one graph-replay was independently
+    # re-verified to be numerically fine (diff indistinguishable from
+    # forward_one's own eager-mode noise floor, which is nonzero for an
+    # unrelated reason: CMix's SPMV_OP/cuda_spmv_forward kernel uses
+    # atomicAdd and isn't bit-deterministic run-to-run). This is consistent
+    # with, and strengthens, the stream-argument theory: the one kernel
+    # launch without an explicit stream is the one that diverges; the ones
+    # with an explicit stream do not. See
+    # /tmp/rwkv_swarm_reports/kernel-investigation.md and
+    # /tmp/rwkv_swarm_reports/controller-kernel-investigation.md for the
+    # full investigation, independent re-verification, and repro scripts.
     def _init_cuda_graph_state(self, token, state, out):
         x_emb = self.model.z["emb.weight"][token]
 


### PR DESCRIPTION
## Summary
Comment-only change (no behavior/functional change). `_init_cuda_graph_state` in `infer/inference_utils.py` is dead code (zero callers anywhere in the tracked codebase) left over from an earlier CUDA-graph-based inference API that was incidentally removed in a prior refactor. Investigation into whether it's worth reviving found a real, non-obvious correctness bug:

**Manually capturing a CUDA graph around this model's batched decode step (`forward_batch` / `forward_seq_batch_tensor` → `cuda_forward_seq`) succeeds without any exception, but produces numerically wrong output on replay.** Root cause: `cuda_forward_seq`'s kernel launch (in `infer/rwkv_batch/cuda/rwkv7_state_fwd_fp16.cu`) omits an explicit CUDA stream argument, unlike `cuda_forward_one` and `cuda_spmv_forward`, which both pass `at::cuda::getCurrentCUDAStream()`. This asymmetry is a clean, positive explanation for the divergence. The single-sequence `forward_one`/`cuda_forward_one` decode path does not have this problem — it was independently re-verified to be numerically fine under graph capture, which only strengthens the stream-argument root-cause theory (the one kernel launch without an explicit stream is the one that diverges; the ones with an explicit stream do not).

This is added as a warning comment above `_init_cuda_graph_state` so nobody revives CUDA graph support here without first fixing the stream argument and re-verifying correctness.

## Verification
Confirmed via a controlled eager-vs-eager control (bit-exact, diff 0.0) versus graph-vs-eager (diff 15-26, logit magnitude ~4-9 — not fp16 noise), reproduced independently with entirely separate scripts, batch sizes, and prompts, with the same qualitative result.