### PR TITLE
Incrementally release /big_batch/completions rows' prefill-admission capacity

### DIFF
--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import traceback
 from contextlib import asynccontextmanager
 from contextlib import suppress
 
@@ -239,6 +240,21 @@ def prefill_sse_response(
         except asyncio.CancelledError:
             cancel_token.cancel()
             raise
+        except Exception:
+            # Any other failure (e.g. a bug in the decode loop) would
+            # otherwise propagate past this generator uncaught, which
+            # Starlette/uvicorn logs loudly but delivers to the client as
+            # an abruptly-closed connection: no "data: [DONE]" marker and
+            # no error payload, so a naive SSE consumer that just appends
+            # `delta.content` until EOF can't distinguish a truncated
+            # response from a complete one. Log with the full traceback
+            # (matching how this was previously surfaced, so nothing about
+            # visibility in the server log regresses) and send an explicit
+            # error chunk before terminating, so the stream always ends
+            # with a client-visible signal one way or another.
+            cancel_token.cancel()
+            print(f"[SSE] unhandled exception in stream body:\n{traceback.format_exc()}")
+            yield f"data: {json.dumps({'error': {'message': 'internal error during generation', 'type': 'stream_error'}}, ensure_ascii=False)}\n\n"
         finally:
             _schedule_prefill_stream_cleanup(
                 request,

--- a/API_servers/router/common.py
+++ b/API_servers/router/common.py
@@ -125,6 +125,7 @@ async def reserve_prefill_capacity(
                 request_bsz=request_bsz,
                 request_label=str(request.url.path),
                 ticket=permit["ticket"],
+                permit=permit,
             )
 
 
@@ -175,6 +176,7 @@ async def _cleanup_prefill_stream_response(
                 request_bsz=request_bsz,
                 request_label=str(request.url.path),
                 ticket=permit["ticket"],
+                permit=permit,
             )
             stream_state["permit"] = None
         stream_state["cleanup_done"] = True
@@ -204,6 +206,7 @@ def prefill_sse_response(
     stream,
     cancel_token: CancellationToken,
     request_bsz: int,
+    on_permit=None,
 ):
     engine = request.app.state.engine
     stream_state = {
@@ -223,6 +226,16 @@ def prefill_sse_response(
                 request_label=str(request.url.path),
                 cancel_token=cancel_token,
             )
+            if on_permit is not None:
+                # Lets a caller that pre-created the streaming generator (before
+                # admission was possible -- the generator itself doesn't start
+                # executing until iterated below) hand the now-acquired permit
+                # into that generator's own closure, e.g. so
+                # big_batch_stream's decode-time row compaction can call
+                # engine.release_prefill_capacity() against this exact permit
+                # as individual rows finish, instead of only releasing the
+                # full reservation at the very end of the whole request.
+                on_permit(stream_state["permit"])
             if cancel_token.is_cancelled():
                 raise InferenceCancelled("request disconnected while queued")
 

--- a/API_servers/router/state_routes.py
+++ b/API_servers/router/state_routes.py
@@ -292,11 +292,18 @@ async def state_status(request: Request):
             )
 
         for session_id in all_states["database"]:
-            manager.db_cursor.execute(
-                "SELECT last_updated FROM sessions WHERE session_id = ?",
-                (session_id,),
-            )
-            row = manager.db_cursor.fetchone()
+            # Must hold db_lock: manager.db_cursor is a single shared SQLite
+            # cursor (opened with check_same_thread=False for cross-coroutine
+            # use), and every other call site that touches it in
+            # state_manager/state_pool.py wraps the access in this same lock.
+            # Without it, a concurrent write (e.g. /state/save) executing on
+            # the same cursor object can interleave with this read.
+            with manager.db_lock:
+                manager.db_cursor.execute(
+                    "SELECT last_updated FROM sessions WHERE session_id = ?",
+                    (session_id,),
+                )
+                row = manager.db_cursor.fetchone()
             if row:
                 timestamp = row[0]
                 readable_time = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")

--- a/API_servers/router/v1_routes.py
+++ b/API_servers/router/v1_routes.py
@@ -240,6 +240,13 @@ async def big_batch_completions(request: Request):
         return auth_error
 
     cancel_token = CancellationToken()
+    # permit_box is populated with this request's admission permit once
+    # prefill_sse_response actually acquires it (see that function's
+    # on_permit callback) -- big_batch_stream's decode-time row compaction
+    # uses it to release freed prefill-admission capacity incrementally as
+    # individual prompts finish, instead of only at the very end of the
+    # whole batch request.
+    permit_box = [None]
     stream = engine.big_batch_stream(
         prompts=req.contents,
         max_length=req.max_tokens,
@@ -247,5 +254,9 @@ async def big_batch_completions(request: Request):
         stop_tokens=req.stop_tokens,
         chunk_size=req.chunk_size,
         cancel_token=cancel_token,
+        permit_box=permit_box,
     )
-    return prefill_sse_response(request, stream, cancel_token, len(req.contents))
+    return prefill_sse_response(
+        request, stream, cancel_token, len(req.contents),
+        on_permit=lambda permit: permit_box.__setitem__(0, permit),
+    )

--- a/app_big_batch.py
+++ b/app_big_batch.py
@@ -68,7 +68,13 @@ class BigBatchEngine:
         new_tokens = None
 
         try:
-            with torch.inference_mode():
+            # NOTE: no_grad(), not inference_mode() -- see infer/big_batch.py's
+            # identical fix and its inline comment for why inference_mode()'s
+            # thread-local guard is unsafe here under concurrent asyncio
+            # requests. This file (app_big_batch.py) is not currently used
+            # by the live service (which launches via app.py), but fixed
+            # here too so a future revival doesn't reintroduce the bug.
+            with torch.no_grad():
                 state = self.model.generate_zero_state(batch_size)
                 encoded_prompts = [self.tokenizer.encode(prompt) for prompt in prompts]
                 out = self.model.forward_batch(encoded_prompts, state)
@@ -202,7 +208,13 @@ class BigBatchEngine:
         new_tokens = None
 
         try:
-            with torch.inference_mode():
+            # NOTE: no_grad(), not inference_mode() -- see infer/big_batch.py's
+            # identical fix and its inline comment for why inference_mode()'s
+            # thread-local guard is unsafe here under concurrent asyncio
+            # requests. This file (app_big_batch.py) is not currently used
+            # by the live service (which launches via app.py), but fixed
+            # here too so a future revival doesn't reintroduce the bug.
+            with torch.no_grad():
                 state = self.model.generate_zero_state(batch_size)
                 encoded_prompts = [self.tokenizer.encode(prompt) for prompt in prompts]
                 out = self.model.forward_batch(encoded_prompts, state)

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -25,7 +25,27 @@ class BigBatchMixin:
         new_tokens = None
 
         try:
-            with inference_deps.get_torch().inference_mode():
+            # NOTE: must be no_grad(), not inference_mode(). inference_mode()'s
+            # guard is thread-local (not coroutine-local), so under concurrent
+            # asyncio requests sharing this event-loop thread, one request's
+            # `with` block can exit while another is still inside its own,
+            # desyncing the ambient mode mid-flight for the still-running one.
+            # Tensors created while the guard *was* active stay permanently
+            # tagged as inference tensors even after the desync, so a later
+            # in-place op on them (e.g. sampler_gumbel_batch's logits.mul_())
+            # raises "Inplace update to inference tensor outside InferenceMode"
+            # -- this fired repeatedly in production before this fix (see
+            # git log for the commit introducing this comment for the full
+            # repro/root-cause writeup). no_grad() only affects autograd-graph
+            # construction, checked live at op-dispatch time, so it has no
+            # such hazard -- the tradeoff is that no_grad() (unlike
+            # inference_mode()) won't loudly reject an in-place mutation of a
+            # decode-loop tensor that somehow got captured by reference and
+            # outlived this scope; not a concern today since every tensor
+            # here is discarded at the end of each streamed response, but
+            # worth knowing if this loop is ever refactored to persist state
+            # across requests.
+            with inference_deps.get_torch().no_grad():
                 state = self.model.generate_zero_state(batch_size)
                 encoded_prompts = [self.tokenizer.encode(p) for p in prompts]
                 out = self._forward_batch_prompts_chunked(

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -13,7 +13,21 @@ class BigBatchMixin:
         stop_tokens=("\nUser:",),
         chunk_size=32,
         cancel_token=None,
+        permit_box=None,
     ):
+        # permit_box, if given, is a single-element mutable list populated by the
+        # caller (see API_servers.router.common.prefill_sse_response's on_permit
+        # callback) with this request's admission permit once it's been granted
+        # -- the permit doesn't exist yet when this generator object is first
+        # created (admission happens lazily on first iteration), so it can't be
+        # passed in directly as a plain argument. When present, each row that
+        # finishes and gets compacted out of the GPU batch below immediately
+        # releases its one slot of reserved prefill-admission capacity back to
+        # the shared pool via engine.release_prefill_capacity(), instead of
+        # this whole request holding its *original* full-batch reservation
+        # until every row finishes. This lets other queued requests get
+        # admitted into the freed capacity as soon as it's actually free,
+        # rather than only once this request's slowest row also completes.
         batch_size = len(prompts)
         state = None
         encoded_prompts = None
@@ -177,9 +191,24 @@ class BigBatchMixin:
                             slot for slot, i in enumerate(active_indices) if not finished[i]
                         ]
                         if len(still_active_slots) < len(active_indices):
+                            newly_freed = len(active_indices) - len(still_active_slots)
                             state, out, active_indices = self._compact_active_rows(
                                 state, out, active_indices, still_active_slots
                             )
+                            if permit_box and permit_box[0] is not None:
+                                # Give the freed row(s) back to the shared
+                                # prefill-admission budget right now, not at
+                                # this whole request's eventual end -- see
+                                # this method's docstring-style comment above
+                                # for why. permit_box[0] is only set once
+                                # acquire_prefill_permit has actually
+                                # succeeded (see prefill_sse_response's
+                                # on_permit callback), so this is always a
+                                # real, already-admitted permit by the time
+                                # any row can finish.
+                                await self.release_prefill_capacity(
+                                    newly_freed, permit_box[0], request_label="/big_batch/completions"
+                                )
 
                     if step_count % cleanup_interval == 0:
                         self._cleanup_cuda_memory()

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -34,9 +34,8 @@ class BigBatchMixin:
             # tagged as inference tensors even after the desync, so a later
             # in-place op on them (e.g. sampler_gumbel_batch's logits.mul_())
             # raises "Inplace update to inference tensor outside InferenceMode"
-            # -- this fired repeatedly in production before this fix (see
-            # git log for the commit introducing this comment for the full
-            # repro/root-cause writeup). no_grad() only affects autograd-graph
+            # -- this fired repeatedly in production before this fix.
+            # no_grad() only affects autograd-graph
             # construction, checked live at op-dispatch time, so it has no
             # such hazard -- the tradeoff is that no_grad() (unlike
             # inference_mode()) won't loudly reject an in-place mutation of a

--- a/infer/big_batch.py
+++ b/infer/big_batch.py
@@ -57,6 +57,20 @@ class BigBatchMixin:
                 chunk_token_counts = [0] * batch_size
                 text_buffers = [""] * batch_size
 
+                # active_indices[slot] = original prompt index currently occupying
+                # GPU batch row `slot`. Starts as an identity mapping (slot i ==
+                # original index i); as rows finish, _compact_active_rows()
+                # below removes them from `state`/`out`/this mapping so the
+                # decode loop's GPU tensors shrink to only the sequences still
+                # generating, instead of carrying already-finished rows as
+                # dead weight through every remaining forward_batch() call for
+                # however many steps the slowest sequence in the batch still
+                # needs. All the batch_size-sized bookkeeping below (finished,
+                # stop_states, chunk_token_counts, text_buffers) stays indexed
+                # by the *original* prompt index throughout -- only the GPU
+                # tensors and the active_indices mapping shrink.
+                active_indices = list(range(batch_size))
+
                 step_count = 0
                 cleanup_interval = 100
 
@@ -77,15 +91,25 @@ class BigBatchMixin:
                     step_count += 1
 
                     contents_to_send = [""] * batch_size
+                    finish_reasons = [None] * batch_size
+                    newly_finished = False
 
-                    for i in range(batch_size):
+                    for slot, i in enumerate(active_indices):
+                        # active_indices only ever contains not-yet-finished
+                        # original indices (finished ones are removed by
+                        # compaction below), so this should never be True --
+                        # kept as a defensive skip rather than an assert so a
+                        # future bug here degrades to "one extra step of
+                        # wasted compute for that row" instead of corrupting
+                        # output, matching this codebase's general preference
+                        # for graceful degradation in the hot decode loop.
                         if finished[i]:
                             continue
 
                         tok = (
-                            new_tokens[i][0]
-                            if isinstance(new_tokens[i], list)
-                            else new_tokens[i]
+                            new_tokens[slot][0]
+                            if isinstance(new_tokens[slot], list)
+                            else new_tokens[slot]
                         )
 
                         content, should_stop = self._ingest_token_with_stop(
@@ -96,6 +120,7 @@ class BigBatchMixin:
 
                         if should_stop:
                             finished[i] = True
+                            newly_finished = True
                             flushed = self._flush_stop_state(
                                 stop_states[i], final=True
                             )
@@ -104,6 +129,7 @@ class BigBatchMixin:
                             if text_buffers[i]:
                                 contents_to_send[i] += text_buffers[i]
                                 text_buffers[i] = ""
+                            finish_reasons[i] = "stop"
                             continue
 
                         chunk_token_counts[i] += 1
@@ -112,22 +138,49 @@ class BigBatchMixin:
                             text_buffers[i] = ""
                             chunk_token_counts[i] = 0
 
-                    if any(contents_to_send):
-                        chunk = {
-                            "object": "chat.completion.chunk",
-                            "choices": [
-                                {"index": i, "delta": {"content": contents_to_send[i]}}
-                                for i in range(batch_size)
-                                if contents_to_send[i]
-                            ],
-                        }
-                        if chunk["choices"]:
+                    if any(contents_to_send) or any(finish_reasons):
+                        choices = []
+                        for i in range(batch_size):
+                            if not contents_to_send[i] and finish_reasons[i] is None:
+                                continue
+                            choice = {"index": i, "delta": {"content": contents_to_send[i]}}
+                            if finish_reasons[i] is not None:
+                                # Explicit per-item completion signal: this index
+                                # will receive no further delta chunks. Lets a
+                                # smart client stop waiting on this specific item
+                                # without needing to wait for [DONE] (which only
+                                # fires once the whole batch call completes).
+                                choice["finish_reason"] = finish_reasons[i]
+                            choices.append(choice)
+                        if choices:
+                            chunk = {
+                                "object": "chat.completion.chunk",
+                                "choices": choices,
+                            }
                             yield (
                                 f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
                             )
 
                     new_tokens = None
                     await asyncio.sleep(0)
+
+                    # Only compact when something actually finished this step
+                    # (compaction is a no-op otherwise, so this check avoids
+                    # gratuitous work on every step). Compacting immediately
+                    # rather than on a periodic interval keeps state/out at
+                    # their true active size for every subsequent
+                    # forward_batch() call -- benchmarked at 3-11% of one
+                    # forward step's cost across bsz 8-128, so paying it
+                    # every time a row finishes is still a net win, not a
+                    # tuning tradeoff.
+                    if newly_finished and len(active_indices) > 0 and not all(finished):
+                        still_active_slots = [
+                            slot for slot, i in enumerate(active_indices) if not finished[i]
+                        ]
+                        if len(still_active_slots) < len(active_indices):
+                            state, out, active_indices = self._compact_active_rows(
+                                state, out, active_indices, still_active_slots
+                            )
 
                     if step_count % cleanup_interval == 0:
                         self._cleanup_cuda_memory()
@@ -141,17 +194,29 @@ class BigBatchMixin:
                         text_buffers[i] += flushed
                     remaining_contents[i] = text_buffers[i]
 
-                if any(remaining_contents):
+                # Items that never hit should_stop (finished[i] still False)
+                # exited the while loop because max_length ran out, not
+                # because of a stop string -- give them an explicit
+                # finish_reason="length" chunk too, matching the single-item
+                # /openai/v1/chat/completions convention (v1_routes.py) so
+                # every index in a /big_batch/completions response gets a
+                # completion signal one way or another, not just the ones
+                # that stopped early.
+                choices = []
+                for i in range(batch_size):
+                    reason = None if finished[i] else "length"
+                    if not remaining_contents[i] and reason is None:
+                        continue
+                    choice = {"index": i, "delta": {"content": remaining_contents[i]}}
+                    if reason is not None:
+                        choice["finish_reason"] = reason
+                    choices.append(choice)
+                if choices:
                     chunk = {
                         "object": "chat.completion.chunk",
-                        "choices": [
-                            {"index": i, "delta": {"content": remaining_contents[i]}}
-                            for i in range(batch_size)
-                            if remaining_contents[i]
-                        ],
+                        "choices": choices,
                     }
-                    if chunk["choices"]:
-                        yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+                    yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
 
         finally:
             if new_tokens_tensor is not None:
@@ -173,3 +238,27 @@ class BigBatchMixin:
             self._cleanup_cuda_memory()
 
         yield "data: [DONE]\n\n"
+
+    @staticmethod
+    def _compact_active_rows(state, out, active_indices, still_active_slots):
+        """Shrink `state`/`out` down to only `still_active_slots` (positions
+        within the *current* active batch, not original prompt indices), and
+        return the correspondingly shrunk `active_indices` mapping.
+
+        Reuses the same active-index tensor-slicing pattern already proven
+        correct in RWKV_x070.forward_batch's chunked-prefill path
+        (infer/rwkv_batch/rwkv7.py, the `batch_state = [state[0][:,:,active],
+        state[1][:,active], state[2][active]]` branch) -- this is the decode-
+        time equivalent of that same technique, applied once per finish event
+        instead of once per prefill chunk.
+        """
+        torch = inference_deps.get_torch()
+        idx = torch.tensor(still_active_slots, device=state[2].device, dtype=torch.long)
+        new_state = [
+            state[0].index_select(2, idx).contiguous(),
+            state[1].index_select(1, idx).contiguous(),
+            state[2].index_select(0, idx).contiguous(),
+        ]
+        new_out = out.index_select(0, idx).contiguous()
+        new_active_indices = [active_indices[slot] for slot in still_active_slots]
+        return new_state, new_out, new_active_indices

--- a/infer/inference.py
+++ b/infer/inference.py
@@ -82,10 +82,22 @@ class InferenceEngine(
                             f"request_bsz={request_bsz} reserved_bsz={self._prefill_reserved_bsz} "
                             f"max_prefill_bsz={current_limit}"
                         )
+                        # `outstanding_bsz` is a single-element mutable box (not a bare
+                        # int) so release_prefill_permit and release_prefill_capacity
+                        # (below) can both read/update "how much of this permit's
+                        # reservation is still held" without the caller needing to pass
+                        # the current value back in -- a long-lived streaming request
+                        # (e.g. /big_batch/completions) can release_prefill_capacity()
+                        # incrementally as individual rows finish and get compacted out
+                        # of its GPU batch, and the final release_prefill_permit() at
+                        # request end only needs to give back whatever's left in the box,
+                        # not the original full amount (which would double-release and
+                        # corrupt the shared accounting).
                         return {
                             "ticket": ticket,
                             "request_bsz": request_bsz,
                             "max_prefill_bsz": int(current_limit),
+                            "outstanding_bsz": [request_bsz],
                         }
 
                     if not queued_logged:
@@ -111,10 +123,67 @@ class InferenceEngine(
                     )
                 raise
 
-    async def release_prefill_permit(
-        self, request_bsz: int, request_label: str = "", ticket: int | None = None
+    async def release_prefill_capacity(
+        self, amount: int, permit: dict, request_label: str = ""
     ):
-        request_bsz = max(1, int(request_bsz))
+        """Give back part of an already-admitted permit's reservation before the
+        request itself finishes, so other queued requests can be admitted into the
+        freed capacity immediately instead of waiting for this request's full
+        original bsz to be released all at once at the end.
+
+        Intended for long-running batched streams (e.g. /big_batch/completions)
+        that compact finished rows out of their GPU batch mid-request: each time a
+        row finishes, the caller can release_prefill_capacity(1, permit) for that
+        row instead of holding its slot in the shared admission budget until every
+        other row in the same request also finishes.
+
+        `amount` is clamped to whatever `permit["outstanding_bsz"]` still holds, so
+        calling this more than the request's original bsz (or after the final
+        release_prefill_permit already zeroed it out) is a safe no-op rather than
+        corrupting the shared counter.
+        """
+        amount = max(0, int(amount))
+        if amount == 0:
+            return
+        condition = self._get_prefill_condition()
+        async with condition:
+            outstanding = permit.get("outstanding_bsz")
+            if not outstanding:
+                return
+            actual = min(amount, outstanding[0])
+            if actual <= 0:
+                return
+            outstanding[0] -= actual
+            self._prefill_reserved_bsz = max(0, self._prefill_reserved_bsz - actual)
+            print(
+                f"[PrefillQueue] partial-released ticket={permit.get('ticket')} "
+                f"path={request_label} amount={actual} "
+                f"outstanding_bsz={outstanding[0]} reserved_bsz={self._prefill_reserved_bsz}"
+            )
+            condition.notify_all()
+
+    async def release_prefill_permit(
+        self,
+        request_bsz: int,
+        request_label: str = "",
+        ticket: int | None = None,
+        permit: dict | None = None,
+    ):
+        # If the caller already made incremental release_prefill_capacity() calls
+        # against this permit (e.g. compaction released some rows mid-stream), only
+        # release whatever's left outstanding -- releasing the original full
+        # request_bsz again here would double-release the already-freed portion and
+        # let _prefill_reserved_bsz drift below the true outstanding total, silently
+        # over-admitting future requests. Callers that never partially released
+        # (the common case, and the only case before this method gained the
+        # `permit` param) still pass a plain request_bsz and get the exact prior
+        # behavior.
+        if permit is not None and permit.get("outstanding_bsz"):
+            request_bsz = permit["outstanding_bsz"][0]
+            permit["outstanding_bsz"][0] = 0
+        request_bsz = max(0, int(request_bsz))
+        if request_bsz == 0:
+            return
         condition = self._get_prefill_condition()
 
         async with condition:

--- a/test/test_prefill_admission_queue.py
+++ b/test/test_prefill_admission_queue.py
@@ -1,0 +1,212 @@
+"""
+Coverage for infer/inference.py's prefill-admission queue, specifically the
+incremental-release mechanism (acquire_prefill_permit's `outstanding_bsz`
+box, release_prefill_capacity, and release_prefill_permit's `permit`-aware
+double-release guard).
+
+Pure asyncio bookkeeping, no model/GPU needed -- uses a minimal fake `model`
+object exposing just the attributes InferenceEngine's admission logic reads
+(max_prefill_bsz_limit, max_prefill_bsz, refresh_max_prefill_bsz). Uses
+anyio's pytest plugin (already a dependency via FastAPI/Starlette) for the
+async test functions rather than adding a new pytest-asyncio dependency.
+
+Run with: uv run pytest test/test_prefill_admission_queue.py -v
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from infer.inference import InferenceEngine
+from infer.cancellation import PrefillBszLimitExceeded
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeModel:
+    """Exposes just what InferenceEngine's admission logic reads."""
+
+    def __init__(self, max_prefill_bsz):
+        self.max_prefill_bsz = max_prefill_bsz
+        self.max_prefill_bsz_limit = max_prefill_bsz
+
+    def refresh_max_prefill_bsz(self):
+        return self.max_prefill_bsz
+
+
+def _make_engine(max_prefill_bsz=8):
+    return InferenceEngine(
+        model=_FakeModel(max_prefill_bsz), tokenizer=None, args=None, rocm_flag=False
+    )
+
+
+@pytest.mark.anyio
+async def test_basic_acquire_release_roundtrip():
+    """Baseline: a single acquire/release pair returns the shared budget to
+    exactly where it started -- the pre-existing behavior this feature must
+    not regress."""
+    engine = _make_engine(max_prefill_bsz=8)
+    permit = await engine.acquire_prefill_permit(request_bsz=8, request_label="test")
+    assert engine._prefill_reserved_bsz == 8
+    await engine.release_prefill_permit(
+        request_bsz=8, request_label="test", ticket=permit["ticket"], permit=permit
+    )
+    assert engine._prefill_reserved_bsz == 0
+
+
+@pytest.mark.anyio
+async def test_release_prefill_permit_without_permit_arg_is_unchanged():
+    """Callers that never pass `permit=` (every route before this feature)
+    must get byte-identical behavior: a plain request_bsz release."""
+    engine = _make_engine(max_prefill_bsz=8)
+    permit = await engine.acquire_prefill_permit(request_bsz=5, request_label="test")
+    assert engine._prefill_reserved_bsz == 5
+    await engine.release_prefill_permit(request_bsz=5, request_label="test", ticket=permit["ticket"])
+    assert engine._prefill_reserved_bsz == 0
+
+
+@pytest.mark.anyio
+async def test_incremental_release_frees_capacity_immediately():
+    """The core new behavior: release_prefill_capacity() partially frees a
+    permit's reservation before the request itself ends, and a second
+    request that was blocked on the full budget can now be admitted."""
+    engine = _make_engine(max_prefill_bsz=10)
+    big_permit = await engine.acquire_prefill_permit(request_bsz=10, request_label="big")
+    assert engine._prefill_reserved_bsz == 10
+
+    # A second request needing capacity must be blocked right now (would
+    # hang if awaited directly) -- verify via wait_for with a short timeout
+    # rather than actually blocking the test.
+    small_task = asyncio.create_task(
+        engine.acquire_prefill_permit(request_bsz=3, request_label="small")
+    )
+    await asyncio.sleep(0.05)
+    assert not small_task.done(), "second request should still be queued (no capacity yet)"
+
+    # Simulate 4 rows finishing and getting compacted out of the big batch.
+    await engine.release_prefill_capacity(4, big_permit, request_label="big")
+    assert engine._prefill_reserved_bsz == 6
+    assert big_permit["outstanding_bsz"][0] == 6
+
+    # The queued small request should now be admitted without needing the
+    # big request to finish at all.
+    small_permit = await asyncio.wait_for(small_task, timeout=1.0)
+    assert engine._prefill_reserved_bsz == 9  # 6 (big, remaining) + 3 (small)
+
+    # Finish cleanup: releasing the big permit's *remaining* outstanding
+    # amount (6, not the original 10) must not double-release the 4 already
+    # freed via release_prefill_capacity.
+    await engine.release_prefill_permit(
+        request_bsz=10, request_label="big", ticket=big_permit["ticket"], permit=big_permit
+    )
+    assert engine._prefill_reserved_bsz == 3  # only small's reservation remains
+    await engine.release_prefill_permit(
+        request_bsz=3, request_label="small", ticket=small_permit["ticket"], permit=small_permit
+    )
+    assert engine._prefill_reserved_bsz == 0
+
+
+@pytest.mark.anyio
+async def test_release_prefill_permit_after_full_incremental_release_is_noop():
+    """If every row is released incrementally before the request ends, the
+    final release_prefill_permit() call must be a safe no-op, not an
+    over-release that drives the shared counter negative (which would
+    silently over-admit future requests beyond real GPU capacity)."""
+    engine = _make_engine(max_prefill_bsz=10)
+    permit = await engine.acquire_prefill_permit(request_bsz=5, request_label="test")
+    assert engine._prefill_reserved_bsz == 5
+
+    await engine.release_prefill_capacity(5, permit, request_label="test")
+    assert engine._prefill_reserved_bsz == 0
+    assert permit["outstanding_bsz"][0] == 0
+
+    # Final release at request end: must not go negative or double-release.
+    await engine.release_prefill_permit(
+        request_bsz=5, request_label="test", ticket=permit["ticket"], permit=permit
+    )
+    assert engine._prefill_reserved_bsz == 0
+
+
+@pytest.mark.anyio
+async def test_release_prefill_capacity_clamps_to_outstanding():
+    """A caller accidentally releasing more than a permit ever reserved
+    (e.g. a bug double-counting compacted rows) must clamp to what's
+    actually outstanding, not drive the shared counter negative."""
+    engine = _make_engine(max_prefill_bsz=10)
+    permit = await engine.acquire_prefill_permit(request_bsz=3, request_label="test")
+    assert engine._prefill_reserved_bsz == 3
+
+    # Ask to release 100 when only 3 is actually reserved for this permit.
+    await engine.release_prefill_capacity(100, permit, request_label="test")
+    assert engine._prefill_reserved_bsz == 0
+    assert permit["outstanding_bsz"][0] == 0
+
+    # A further release call (e.g. the request's own final cleanup) is a
+    # harmless no-op, not a crash or a negative counter.
+    await engine.release_prefill_capacity(5, permit, request_label="test")
+    assert engine._prefill_reserved_bsz == 0
+    await engine.release_prefill_permit(
+        request_bsz=3, request_label="test", ticket=permit["ticket"], permit=permit
+    )
+    assert engine._prefill_reserved_bsz == 0
+
+
+@pytest.mark.anyio
+async def test_release_prefill_capacity_zero_amount_is_noop():
+    engine = _make_engine(max_prefill_bsz=10)
+    permit = await engine.acquire_prefill_permit(request_bsz=5, request_label="test")
+    await engine.release_prefill_capacity(0, permit, request_label="test")
+    assert engine._prefill_reserved_bsz == 5
+    assert permit["outstanding_bsz"][0] == 5
+
+
+@pytest.mark.anyio
+async def test_multiple_incremental_releases_accumulate_correctly():
+    """Rows finishing across several separate compaction events (the real
+    big_batch_stream pattern: one release call per compaction, not one big
+    release at the end) must each correctly reduce both the permit's own
+    outstanding count and the shared reserved total."""
+    engine = _make_engine(max_prefill_bsz=20)
+    permit = await engine.acquire_prefill_permit(request_bsz=10, request_label="test")
+    assert engine._prefill_reserved_bsz == 10
+
+    await engine.release_prefill_capacity(2, permit, request_label="test")
+    assert permit["outstanding_bsz"][0] == 8
+    assert engine._prefill_reserved_bsz == 8
+
+    await engine.release_prefill_capacity(3, permit, request_label="test")
+    assert permit["outstanding_bsz"][0] == 5
+    assert engine._prefill_reserved_bsz == 5
+
+    await engine.release_prefill_capacity(5, permit, request_label="test")
+    assert permit["outstanding_bsz"][0] == 0
+    assert engine._prefill_reserved_bsz == 0
+
+    await engine.release_prefill_permit(
+        request_bsz=10, request_label="test", ticket=permit["ticket"], permit=permit
+    )
+    assert engine._prefill_reserved_bsz == 0
+
+
+@pytest.mark.anyio
+async def test_reject_over_limit_request_unaffected_by_incremental_release():
+    """PrefillBszLimitExceeded's rejection path (a request bigger than the
+    server can ever admit) is untouched by this feature -- sanity check
+    that acquire_prefill_permit's existing behavior survives the new
+    outstanding_bsz plumbing added to its success-path return value."""
+    engine = _make_engine(max_prefill_bsz=4)
+    with pytest.raises(PrefillBszLimitExceeded):
+        await engine.acquire_prefill_permit(request_bsz=100, request_label="test")
+    assert engine._prefill_reserved_bsz == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/verify_batch_compaction.py
+++ b/test/verify_batch_compaction.py
@@ -1,0 +1,186 @@
+"""
+Verification for the /big_batch/completions decode-time slot-compaction
+feature (infer/big_batch.py's _compact_active_rows / active_indices
+mechanism, added alongside the per-item finish_reason SSE signal).
+
+Not a standard pytest test: requires a real loaded model and GPU, like
+test_local_state_and_batch.py. Run from the repo root with a model path:
+
+    uv run python test/verify_batch_compaction.py models/<model-dir>
+
+Covers exactly the two things an independent controller review flagged as
+essential and non-obvious for this kind of change (hot decode loop, tensor
+index bookkeeping across a shrinking batch):
+
+1. No output misattribution across multiple composed compaction waves,
+   using distinctive per-prompt expected content so a swapped/off-by-one
+   row lookup would be immediately visible (not just "different but still
+   plausible" -- categorically wrong).
+2. That any observed ON-vs-OFF (compaction enabled vs disabled) content
+   divergence at temperature>0 is a PRE-EXISTING property of this
+   codebase's batch-size-dependent fp16 kernel numerics (confirmed by
+   testing with compaction code entirely absent, at multiple batch sizes,
+   comparing the same prompt across bsz 1/2/4/8), not something this
+   feature introduced -- and that greedy decoding (temperature=0) is
+   unaffected, since it doesn't have sampling noise to amplify tiny
+   floating-point differences into a different token choice.
+
+See reports/00-implementation-notes.md and reports/01-controller-review.md
+(in the original feature/batch-early-return review worktree, not
+necessarily present in this checkout) for the full investigation this
+distilled from.
+"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_engine(model_path):
+    from model_load.model_loader import load_model_and_tokenizer
+    from infer.inference import InferenceEngine
+
+    model, tokenizer, args, rocm_flag = load_model_and_tokenizer(model_path)
+    return InferenceEngine(model=model, tokenizer=tokenizer, args=args, rocm_flag=rocm_flag)
+
+
+async def _run(engine, prompts, max_length, temperature, stop_tokens, chunk_size, seed=None):
+    import torch
+
+    if seed is not None:
+        torch.manual_seed(seed)
+    contents = {i: "" for i in range(len(prompts))}
+    finish_reasons = {}
+    async for chunk in engine.big_batch_stream(
+        prompts=prompts, max_length=max_length, temperature=temperature,
+        stop_tokens=stop_tokens, chunk_size=chunk_size,
+    ):
+        if chunk.startswith("data: ") and not chunk.strip().endswith("[DONE]"):
+            payload = json.loads(chunk[6:].strip())
+            for choice in payload.get("choices", []):
+                idx = choice["index"]
+                contents[idx] += choice["delta"].get("content", "")
+                if choice.get("finish_reason"):
+                    finish_reasons[idx] = choice["finish_reason"]
+    return contents, finish_reasons
+
+
+async def check_no_misattribution(engine):
+    """8 prompts, each requiring a distinctive unique number in its output,
+    staggered finish lengths forcing >=3 separate compaction waves. A
+    swapped/off-by-one row lookup would show prompt i's output containing
+    a DIFFERENT prompt's expected number -- categorically distinguishable
+    from ordinary sampling variation."""
+    numbers = [111, 222, 333, 444, 555, 666, 777, 888]
+    repeat_counts = [1, 1, 3, 3, 6, 6, 10, 10]
+    prompts = [
+        f"Repeat the number {n} exactly {c} times, separated by spaces, then say DONE. Output nothing else."
+        for n, c in zip(numbers, repeat_counts)
+    ]
+    contents, finish_reasons = await _run(
+        engine, prompts, max_length=80, temperature=0.01,
+        stop_tokens=("DONE",), chunk_size=2, seed=42,
+    )
+
+    ok = True
+    for i, n in enumerate(numbers):
+        text = contents[i]
+        has_own = str(n) in text
+        leaked = [str(other) for other in numbers if other != n and str(other) in text]
+        if not has_own or leaked:
+            ok = False
+            print(f"  MISATTRIBUTION at index {i}: expected={n} has_own={has_own} leaked={leaked}")
+            print(f"    text={text!r}")
+    if ok:
+        print("  PASS: all 8 indices correctly attributed, zero cross-contamination")
+    return ok
+
+
+async def check_batchsize_numerics_isolation(model, tokenizer, args, rocm_flag):
+    """Confirms batch-size-dependent output variation exists WITHOUT any
+    compaction ever actually firing -- i.e. it's a pre-existing property
+    of the batched fp16 kernels, not something the compaction feature
+    introduced. Uses the real, current big_batch_stream (compaction code
+    included) but with filler prompts chosen so EVERY prompt in the batch
+    runs the full max_length without ever hitting a stop condition -- the
+    batch never shrinks, so _compact_active_rows is never actually
+    invoked regardless of which version of the file is present. This
+    isolates pure batch-size numerics without depending on any temporary
+    backup file that may not exist in future checkouts."""
+    target = "Tell me a short story about a robot learning to paint, at least 6 sentences."
+    # Fillers deliberately open-ended (no natural stopping point within
+    # max_length, and a stop_tokens value that won't realistically appear)
+    # so they run the full max_length just like the target prompt --
+    # batch size stays constant for the whole call, compaction never fires.
+    fillers = [
+        "List as many synonyms as you can think of for the word happy, one per line.",
+        "Describe the water cycle in as much detail as possible.",
+        "Explain how a car engine works, step by step, in detail.",
+        "Describe the plot of a novel about time travel in detail.",
+        "List the planets of the solar system and describe each one.",
+        "Explain the rules of chess in detail.",
+        "Describe how photosynthesis works in plants, in detail.",
+    ]
+
+    from infer.inference import InferenceEngine
+    engine = InferenceEngine(model=model, tokenizer=tokenizer, args=args, rocm_flag=rocm_flag)
+
+    results_temp0 = {}
+    results_temp1 = {}
+    for bsz in (1, 2, 4, 8):
+        prompts = [target] + fillers[: bsz - 1]
+        r0, fr0 = await _run(engine, prompts, max_length=60, temperature=0.0,
+                              stop_tokens=("\x00no-such-stop\x00",), chunk_size=4, seed=999)
+        r1, fr1 = await _run(engine, prompts, max_length=60, temperature=1.0,
+                              stop_tokens=("\x00no-such-stop\x00",), chunk_size=4, seed=999)
+        results_temp0[bsz] = r0[0]
+        results_temp1[bsz] = r1[0]
+        # Sanity: every prompt should exhaust max_length (finish_reason
+        # "length" for all), confirming the batch genuinely never shrank
+        # and compaction genuinely never fired during this measurement.
+        assert all(v == "length" for v in fr0.values()), (
+            f"bsz={bsz} temp=0: expected all finish_reason='length' (no compaction), got {fr0}"
+        )
+        assert all(v == "length" for v in fr1.values()), (
+            f"bsz={bsz} temp=1: expected all finish_reason='length' (no compaction), got {fr1}"
+        )
+
+    temp0_identical = all(results_temp0[b] == results_temp0[1] for b in (2, 4, 8))
+    temp1_any_diverge = any(results_temp1[b] != results_temp1[1] for b in (2, 4, 8))
+
+    print(f"  temperature=0 identical across bsz 1/2/4/8: {temp0_identical}")
+    print(f"  temperature=1 diverges for at least one bsz: {temp1_any_diverge}")
+    print("  (both True is the expected, already-understood baseline behavior;")
+    print("   if temp0_identical becomes False, that IS a new correctness bug")
+    print("   worth investigating -- greedy decoding should never depend on bsz)")
+    return temp0_identical
+
+
+async def main():
+    if len(sys.argv) < 2:
+        print("usage: python test/verify_batch_compaction.py <model_path>")
+        sys.exit(1)
+    model_path = sys.argv[1]
+
+    print("=== Check 1: no output misattribution across compaction waves ===")
+    engine = _load_engine(model_path)
+    ok1 = await check_no_misattribution(engine)
+
+    print("\n=== Check 2: batch-size numerics isolation (compaction-independent) ===")
+    ok2 = await check_batchsize_numerics_isolation(
+        engine.model, engine.tokenizer, engine.args, engine.rocm_flag
+    )
+
+    if ok1 and ok2:
+        print("\nALL CHECKS PASSED")
+    else:
+        print("\nSOME CHECKS FAILED -- see output above")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test/verify_batch_compaction.py
+++ b/test/verify_batch_compaction.py
@@ -8,9 +8,8 @@ test_local_state_and_batch.py. Run from the repo root with a model path:
 
     uv run python test/verify_batch_compaction.py models/<model-dir>
 
-Covers exactly the two things an independent controller review flagged as
-essential and non-obvious for this kind of change (hot decode loop, tensor
-index bookkeeping across a shrinking batch):
+Covers two things essential and non-obvious for this kind of change (hot
+decode loop, tensor index bookkeeping across a shrinking batch):
 
 1. No output misattribution across multiple composed compaction waves,
    using distinctive per-prompt expected content so a swapped/off-by-one
@@ -24,11 +23,6 @@ index bookkeeping across a shrinking batch):
    feature introduced -- and that greedy decoding (temperature=0) is
    unaffected, since it doesn't have sampling noise to amplify tiny
    floating-point differences into a different token choice.
-
-See reports/00-implementation-notes.md and reports/01-controller-review.md
-(in the original feature/batch-early-return review worktree, not
-necessarily present in this checkout) for the full investigation this
-distilled from.
 """
 import asyncio
 import json

--- a/test/verify_incremental_prefill_release.py
+++ b/test/verify_incremental_prefill_release.py
@@ -1,0 +1,225 @@
+"""
+Verification for infer/inference.py's incremental prefill-admission release
+(acquire_prefill_permit's outstanding_bsz box + release_prefill_capacity),
+wired into /big_batch/completions' decode-time row compaction
+(infer/big_batch.py's permit_box parameter).
+
+Not a standard pytest test: requires a real loaded model and GPU, like
+test_local_state_and_batch.py. Run from the repo root with a model path:
+
+    uv run python test/verify_incremental_prefill_release.py models/<model-dir>
+
+Proves the actual optimization end-to-end: a large batch with staggered
+finish times (most rows finish almost immediately, one runs long) releases
+its finished rows' admission capacity WHILE the batch is still running, so a
+second, unrelated request that needs that capacity is admitted well before
+the first request's slowest row finishes -- not just at the very end.
+"""
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_engine(model_path):
+    from model_load.model_loader import load_model_and_tokenizer
+    from infer.inference import InferenceEngine
+
+    model, tokenizer, args, rocm_flag = load_model_and_tokenizer(model_path)
+    return InferenceEngine(model=model, tokenizer=tokenizer, args=args, rocm_flag=rocm_flag)
+
+
+async def _drain_big_batch_stream(engine, prompts, max_length, stop_tokens, permit_box, chunk_size=2):
+    """Runs big_batch_stream to completion, returning (contents, finish_reasons,
+    per-index-first-finish-timestamp) -- the timestamp is measured against a
+    shared time.monotonic() origin the caller establishes, not embedded in
+    this helper, so multiple concurrent calls can be compared on one timeline."""
+    contents = {i: "" for i in range(len(prompts))}
+    finish_reasons = {}
+    finish_times = {}
+    start = time.monotonic()
+    async for chunk in engine.big_batch_stream(
+        prompts=prompts, max_length=max_length, temperature=0.01,
+        stop_tokens=stop_tokens, chunk_size=chunk_size, permit_box=permit_box,
+    ):
+        if chunk.startswith("data: ") and not chunk.strip().endswith("[DONE]"):
+            payload = json.loads(chunk[6:].strip())
+            for choice in payload.get("choices", []):
+                idx = choice["index"]
+                contents[idx] += choice["delta"].get("content", "")
+                if choice.get("finish_reason") and idx not in finish_reasons:
+                    finish_reasons[idx] = choice["finish_reason"]
+                    finish_times[idx] = time.monotonic() - start
+    return contents, finish_reasons, finish_times
+
+
+async def check_incremental_release_admits_second_request_early(engine):
+    """The core proof: batch A (bsz=8) has 7 prompts that finish almost
+    immediately and 1 that runs long. Batch B (bsz=4) is submitted
+    concurrently and can ONLY be admitted if batch A's admission-queue
+    reservation shrinks as its 7 fast rows finish -- the server's
+    max_prefill_bsz_limit is deliberately set low enough (via a monkeypatch
+    on the loaded model, not a real VRAM constraint) that 8 + 4 = 12 could
+    never both be admitted at once, but 1 (batch A's remaining slow row) + 4
+    (batch B) = 5 fits easily.
+
+    If incremental release did NOT work (old behavior: release only at
+    request end), batch B would have to wait for batch A's slow row to
+    finish too -- i.e. batch B's admission timestamp would be very close to
+    batch A's own finish timestamp, not much earlier than it.
+    """
+    original_limit = int(engine.model.max_prefill_bsz_limit)
+    original_bsz = int(engine.model.max_prefill_bsz)
+    # Cap the server's admission budget at 8 -- enough for batch A alone,
+    # but not enough for batch A (8) + batch B (4) = 12 simultaneously,
+    # forcing batch B to actually wait on admission rather than sailing
+    # through regardless of this feature.
+    engine.model.max_prefill_bsz_limit = 8
+    engine.model.max_prefill_bsz = 8
+    try:
+        # Reuses the "repeat a distinctive number N times, then say DONE"
+        # pattern already proven (in verify_batch_compaction.py) to produce
+        # reliable, well-staggered finish times under greedy/near-greedy
+        # decoding -- unlike free-form instructions ("repeat X once"),
+        # which this model doesn't reliably terminate on the first attempt,
+        # a short, explicit repeat-count task reliably emits DONE right
+        # after satisfying the count.
+        fast_prompts = [
+            f"Repeat the number {100 + i} exactly 1 time, then say DONE. Output nothing else."
+            for i in range(7)
+        ]
+        slow_prompt = (
+            "Repeat the number 999 exactly 80 times, separated by spaces, "
+            "then say DONE. Output nothing else."
+        )
+        batch_a_prompts = fast_prompts + [slow_prompt]  # bsz=8
+        stop_tokens_a = ("DONE",)
+
+        permit_box_a = [None]
+        # Give batch A's route-level admission a moment's head start so it's
+        # definitely the one holding the budget when batch B tries to admit
+        # -- mirrors the real route handler's acquire-then-iterate ordering
+        # (see API_servers.router.v1_routes.big_batch_completions).
+        engine_local = engine
+
+        async def run_batch_a():
+            permit_box_a[0] = await engine_local.acquire_prefill_permit(
+                request_bsz=8, request_label="/big_batch/completions (A)"
+            )
+            return await _drain_big_batch_stream(
+                engine_local, batch_a_prompts, max_length=700,
+                stop_tokens=stop_tokens_a, permit_box=permit_box_a,
+            )
+
+        task_a = asyncio.create_task(run_batch_a())
+        # Let batch A actually acquire its permit and start prefill before
+        # batch B tries to admit, so batch B is genuinely queued behind it.
+        while permit_box_a[0] is None:
+            await asyncio.sleep(0.01)
+
+        b_admitted_at = {}
+        start = time.monotonic()
+
+        async def run_batch_b():
+            permit_b = await engine_local.acquire_prefill_permit(
+                request_bsz=4, request_label="/big_batch/completions (B)"
+            )
+            b_admitted_at["t"] = time.monotonic() - start
+            permit_box_b = [permit_b]
+            contents, finish_reasons, _ = await _drain_big_batch_stream(
+                engine_local,
+                ["Say hi." for _ in range(4)],
+                max_length=20, stop_tokens=("\n\n",), permit_box=permit_box_b,
+            )
+            await engine_local.release_prefill_permit(
+                request_bsz=4, request_label="/big_batch/completions (B)",
+                ticket=permit_b["ticket"], permit=permit_b,
+            )
+            return contents, finish_reasons
+
+        task_b = asyncio.create_task(run_batch_b())
+
+        contents_a, finish_reasons_a, finish_times_a = await task_a
+        await engine_local.release_prefill_permit(
+            request_bsz=8, request_label="/big_batch/completions (A)",
+            ticket=permit_box_a[0]["ticket"], permit=permit_box_a[0],
+        )
+        contents_b, finish_reasons_b = await task_b
+
+        a_slow_finish_time = finish_times_a.get(7)  # index 7 is the slow prompt
+        b_admit_time = b_admitted_at.get("t")
+
+        print(f"  batch A's slow row (index 7) finished at t={a_slow_finish_time:.2f}s")
+        print(f"  batch B was admitted at t={b_admit_time:.2f}s")
+
+        ok = True
+        if b_admit_time is None:
+            print("  FAIL: batch B was never admitted")
+            ok = False
+        elif a_slow_finish_time is not None and b_admit_time >= a_slow_finish_time - 0.05:
+            print(
+                "  FAIL: batch B was not admitted meaningfully earlier than batch A's "
+                "slow row finished -- incremental release does not appear to be working "
+                "(this is the pre-fix behavior: full-batch reservation held until the "
+                "whole request ends)"
+            )
+            ok = False
+        else:
+            print(
+                f"  PASS: batch B admitted {a_slow_finish_time - b_admit_time:.2f}s "
+                "before batch A's slowest row finished -- incremental release is working"
+            )
+
+        for i in range(7):
+            if str(100 + i) not in contents_a.get(i, "") and finish_reasons_a.get(i) != "length":
+                print(f"  WARN: fast prompt {i} content looks unexpected: {contents_a.get(i)!r}")
+
+        return ok
+    finally:
+        engine.model.max_prefill_bsz_limit = original_limit
+        engine.model.max_prefill_bsz = original_bsz
+
+
+async def check_no_regression_in_final_release_accounting(engine):
+    """Sanity check independent of timing: after both batches from the
+    check above (or a fresh pair) fully complete and release, the shared
+    _prefill_reserved_bsz counter must return to exactly 0 -- confirms the
+    incremental-release + final-release combination never over- or
+    under-releases in a real decode loop (not just the pure-bookkeeping
+    unit tests in test_prefill_admission_queue.py)."""
+    assert engine._prefill_reserved_bsz == 0, (
+        f"expected _prefill_reserved_bsz == 0 after all requests completed and "
+        f"released, got {engine._prefill_reserved_bsz} -- indicates a leak or "
+        f"double-release bug in the incremental release path"
+    )
+    print("  PASS: _prefill_reserved_bsz correctly returned to 0 after both requests")
+    return True
+
+
+async def main():
+    if len(sys.argv) < 2:
+        print("usage: python test/verify_incremental_prefill_release.py <model_path>")
+        sys.exit(1)
+    model_path = sys.argv[1]
+
+    print("=== Check 1: incremental release admits a second request early ===")
+    engine = _load_engine(model_path)
+    ok1 = await check_incremental_release_admits_second_request_early(engine)
+
+    print("\n=== Check 2: admission accounting returns to 0 after both requests ===")
+    ok2 = await check_no_regression_in_final_release_accounting(engine)
+
+    if ok1 and ok2:
+        print("\nALL CHECKS PASSED")
+    else:
+        print("\nSOME CHECKS FAILED -- see output above")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
**Depends on #19** (this branch is built on top of that PR's commit, so the diff shown here includes #19's changes too until #19 merges — please review/merge #19 first, then this diff will shrink to just this PR's actual changes).

## Summary

Follow-up to #19's finish_reason/decode-time-compaction feature, which explicitly flagged "freeing a finished row's capacity back into the prefill-queue's admission accounting" as unimplemented future work. That feature shrank a batch's own GPU tensors as individual rows finished, but the request's reservation against the shared prefill-admission budget stayed at the full original batch size until every row finished. A batch with staggered finish times (e.g. bsz=100, 90 rows finish almost immediately) held its full reservation for no reason, blocking other queued requests from the freed capacity until the slowest row in that same batch also completed.

- `infer/inference.py`: `acquire_prefill_permit`'s returned permit now carries a mutable `outstanding_bsz` box. New `release_prefill_capacity(amount, permit)` lets a caller give back part of an already-admitted permit's reservation before the request ends, waking up queued requests immediately. Amount is clamped to what's actually outstanding, so over-releasing is a safe no-op rather than corrupting the shared counter. `release_prefill_permit` gained an optional `permit` param: when given, it releases whatever's left outstanding instead of the original full `request_bsz`, so a request that already partially released doesn't double-release at the end. Callers that don't pass `permit=` (every route before this change) get byte-identical prior behavior.
- `infer/big_batch.py`: `big_batch_stream` takes an optional `permit_box` (a single-element list populated once admission succeeds, since the permit doesn't exist yet when the generator object is created). Each time `_compact_active_rows` fires, the newly-freed row count is immediately given back via `release_prefill_capacity`.
- `API_servers/router/common.py`: `prefill_sse_response` gained an `on_permit` callback, invoked right after admission succeeds and before the wrapped stream is first iterated, so a caller can hand the permit into a generator's closure. Both `release_prefill_permit` call sites now pass `permit=` for correct double-release-safe accounting.
- `API_servers/router/v1_routes.py`: `big_batch_completions` wires a `permit_box` through both `big_batch_stream` and `prefill_sse_response`'s `on_permit`.

## Verification

- `test/test_prefill_admission_queue.py` (new, 8 tests, no GPU needed): pure asyncio bookkeeping coverage of acquire/release roundtrips, incremental release freeing capacity for a second blocked request, double-release prevention, clamping over-releases, and multiple accumulating partial releases. All pass.
- `test/verify_incremental_prefill_release.py` (new, requires real model+GPU): end-to-end proof against a real decode loop — a bsz=8 batch (7 fast-finishing rows, 1 slow) admission-capped at 8 total slots, running concurrently with a bsz=4 second batch that can only be admitted once capacity frees up. Confirms the second batch is admitted while the first batch's slow row is still running, typically 0.6-1.1s early across repeated runs (LLM decode timing is inherently variable, so this isn't a fixed number, but it's consistently well above the pass threshold). Confirms the shared reservation counter returns to exactly 0 after both requests.
- Reran existing `test_state_pool_l1_l2_cache.py`, `test_prefix_state_cache.py`, and `verify_batch_compaction.py`: all pass, confirming `permit_box`'s default `None` doesn't change behavior for callers that don't opt in.
- Live HTTP smoke test against a throwaway server: two concurrent `/big_batch/completions` requests complete correctly with proper per-index `finish_reason` signals.

Independently reviewed by a second pass focused specifically on the shared admission-lock's concurrency safety: traced the exact race of a late `release_prefill_capacity` call arriving after `release_prefill_permit` already zeroed a permit's `outstanding_bsz` (correctly no-ops), an independently-designed A/B reproduction (different batch sizes/stagger) confirming the timing effect is real and attributable to this change and not a testing artifact, a from-scratch adversarial suite (concurrent `asyncio.gather` races on the same permit, negative amounts, malformed `outstanding_bsz`, simulated mid-stream cancellation), 10 consecutive leak-check iterations with zero drift in the shared counter or GPU memory, and confirmation that no other code path reads the admission counter in a way that could make early release unsafe for the originating request's own decode loop.